### PR TITLE
Escape query keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_script:
   - npm install bower
   - 'export PATH=$PWD/node_modules/.bin:$PATH'
   - bower install
-node_js: 4
+node_js: stable
 addons:
   firefox: latest
   apt:

--- a/bower.json
+++ b/bower.json
@@ -32,6 +32,6 @@
   },
   "devDependencies": {
     "web-component-tester": "Polymer/web-component-tester#>=5.0.0",
-    "polymer": "1.3.1 - 2.0.0"
+    "polymer": "<2.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -32,6 +32,6 @@
   },
   "devDependencies": {
     "web-component-tester": "Polymer/web-component-tester#>=5.0.0",
-    "polymer": "<2.0.0"
+    "polymer": "^1.9.1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -32,6 +32,6 @@
   },
   "devDependencies": {
     "web-component-tester": "Polymer/web-component-tester#>=5.0.0",
-    "polymer": ">=1.3.1 <2.0.0"
+    "polymer": "1.3.1 - 2.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -32,6 +32,6 @@
   },
   "devDependencies": {
     "web-component-tester": "Polymer/web-component-tester#>=5.0.0",
-    "polymer": ">=1.3.1"
+    "polymer": ">=1.3.1 <2.0.0"
   }
 }

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -254,7 +254,7 @@ version: 2.3.2
                     for (var key in partial){
                         if (partial.hasOwnProperty(key)) {
                             htmls.push(
-                                key +
+                                encodeURIComponent(key) +
                                 '=' +
                                 (partial[key].Html && encodeURIComponent(partial[key].Html) || defaultURL)
                             );

--- a/test/index.html
+++ b/test/index.html
@@ -31,7 +31,9 @@
         'partialId-property/reflect-partialId-to-attribute.html',
         // compositions
         'composition/declarative-shadow-dom.html',
-        'composition/starcounter-composition.html'
+        'composition/starcounter-composition.html',
+        //internals
+        'internals/buildURL.html'
       ]);
     </script>
   </body>

--- a/test/internals/buildURL.html
+++ b/test/internals/buildURL.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+
+    <script src="../../../web-component-tester/browser.js"></script>
+    <script src="../../../webcomponentsjs/webcomponents.js"></script>
+
+    <!-- Step 1: import the element to test -->
+    <link rel="import" href="../../starcounter-include.html">
+    <script src="../helpers/WCT-Polyfill_bugs_workaround.js"></script>
+</head>
+
+<body>
+    <script>
+    describe('starcounter-include should build a URL to the Htmls', function () {
+        afterEach(function (done) {
+            // give more time to polyfill cleanup
+            setTimeout(done);
+        });
+        var scInclude;
+        var model = {
+            'scope;,/?:@&=+$': {
+                'Html': 'scopeHtml;,/?:@&=+$',
+                'doesItWork': 'works!'
+            }
+        };
+
+        it('should properly escape keys and values in the query string', function (done) {
+            scInclude = document.createElement('starcounter-include');
+            scInclude.partial = clone(model);
+            let importedTemplate = scInclude.querySelector_template_for_buggy_polyfill();
+
+            expect(importedTemplate.getAttribute("content")).to.equal('/sc/htmlmerger?scope%3B%2C%2F%3F%3A%40%26%3D%2B%24=scopeHtml%3B%2C%2F%3F%3A%40%26%3D%2B%24');
+            expect(importedTemplate.model).to.equal(null);
+
+            document.body.appendChild(scInclude);
+
+            importedTemplate.addEventListener('stamping', function onceStamped(){
+                expect(importedTemplate.model).to.equal(scInclude.partial);
+                done();
+            });
+        });
+
+    });
+    function clone(obj) {
+        return JSON.parse(JSON.stringify(obj));
+    }
+    </script>
+
+</body>
+
+</html>


### PR DESCRIPTION
Encode the key in the query parameters, not only the value.

Without this fix, if the JSON key is `app#&?app`, the #&? characters break the query string.

---

This was discovered when testing https://github.com/Starcounter/level1/issues/4017#issuecomment-310460088

The keys `_ver#s` and `_ver#c$` are considered by `starcounter-include` as namespaces and moreover they break the query string, because unescaped `#` has special meaning in web URLs. 

This fix fixes the escaping part of the problem.