### PR TITLE
Clean deprecated LauncherLayoutInfo, fix CompositionProvider

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ If you would like to start to fiddle with element's code, here is the flow we us
 
 In order to develop it locally we suggest to use [polyserve](https://npmjs.com/polyserve) tool to handle bower paths gently.
 
-0. Go to the repo's directory: `cd launcher-include`
+0. Go to the repo's directory: `cd starcounter-include`
 1. Install [bower](http://bower.io/) & [polyserve](https://npmjs.com/polyserve): `$ npm install -g bower polyserve`
 2. Install local dependencies: `$ bower install`
 3. Start development server `$ polyserve -p 8000`

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Attribute     | Options  | Default      | Description
 Property   | Options           | Default | Description
 ---         | ---               | ---     | ---
 `partial`   | *Object*          |         | Object containing partial view-model, bindable with Polymer
-`partialId` | *String*          |         | Partial Id used to identify partial, usually it's fetched from `partial.LauncherLayoutInfo.PartialId`.
+`partialId` | *String*          |         | Partial Id used to identify partial, usually it's fetched from `partial.CompositionProvider.PartialId`.
 `viewModel` | *Object*          |         | Alias for `partial`
 
 ## Events
@@ -142,7 +142,8 @@ Property   | Options           | Default | Description
 Name                                    | Detail                 | Description
 ---                                     | ---                    | ---
 `starcounter-include-composition-saved` | *String* stored layout | Triggered once composition is saved
-`partial-changed`                       | *Object* `{value: storedLayout, path: 'partial.LauncherLayoutInfo.Composition$'}` | Polymer notification protocol compilant event to notify about `partial.LauncherLayoutInfo.Composition$` change, triggered once composition is saved.
+`partial-changed`                       | *Object* `{value: storedLayout, path: 'partial.CompositionProvider.Composition$'}` | Polymer notification protocol compilant event to notify about `partial.CompositionProvider.Composition$` change, triggered once composition is saved.
+`view-model-changed`                       | *Object* `{value: storedLayout, path: 'viewModel.CompositionProvider.Composition$'}` | Polymer notification protocol compilant event to notify about `partial.CompositionProvider.Composition$` change, triggered once composition is saved.
 
 ## Test suite
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-    <title>Launcher include demo</title>
+    <title>Starcounter-include demo</title>
     <script src="../../webcomponentsjs/webcomponents.js"></script>
     <link rel="import" href="../../polymer/polymer.html">
     <link rel="import" href="../starcounter-include.html">

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -1,6 +1,6 @@
 <!--
-`launcher-include` - Launcher's `starcounter-include` -
-Custom Element (w/ Polymer's TempalteBinding)
+`starcounter-include` -
+Custom Element (w/ Polymer's TemplateBinding)
 with predefined template content, which should be used to include partials.
 It's just <template is="imported-template"> wrapped within <juicy-composition> bindable by layout editor.
 Uses juicy-composition.composition given from DB as `Starcounter.MergedPartial.(CompositionProvider|CompositionProvider_0).Composition$`.
@@ -23,14 +23,14 @@ version: 2.3.2
         var isSafari = navigator.vendor && navigator.vendor.indexOf("Apple") > -1 && navigator.userAgent && !navigator.userAgent.match("CriOS");
 
         var templ = (document._currentScript || document.currentScript).ownerDocument.getElementById("partial-template");
-        var LauncherPartialPrototype = Object.create(HTMLElement.prototype);
-        LauncherPartialPrototype.partial = null;
-        LauncherPartialPrototype.partialId = null;
+        var StarcounterIncludePrototype = Object.create(HTMLElement.prototype);
+        StarcounterIncludePrototype.partial = null;
+        StarcounterIncludePrototype.partialId = null;
         //FIXME: this one should not be needed, once we get rid of workarounds for server-side
-        LauncherPartialPrototype.compositionAPI = '/sc/partial/composition';
-        // LauncherPartialPrototype.html = null;
-        LauncherPartialPrototype.mergedHtmlPrefix = '/sc/htmlmerger?';
-        LauncherPartialPrototype.defaultHtml = '';
+        StarcounterIncludePrototype.compositionAPI = '/sc/partial/composition';
+        // StarcounterIncludePrototype.html = null;
+        StarcounterIncludePrototype.mergedHtmlPrefix = '/sc/htmlmerger?';
+        StarcounterIncludePrototype.defaultHtml = '';
         /**
          * @see Starcounter/starcounter-include - partialAttributeToProperty It's just a copy
          */
@@ -48,7 +48,7 @@ version: 2.3.2
         /**
          * Use predefined template content, rewrite attributes.
          */
-        LauncherPartialPrototype.createdCallback = function LPartialCreated() {
+        StarcounterIncludePrototype.createdCallback = function LPartialCreated() {
             // ugly https://code.google.com/p/chromium/issues/detail?id=430578 workaround
             // if( inDocumentFragment( this ) ){
             //   return ;
@@ -138,7 +138,7 @@ version: 2.3.2
         /**
          * @see Starcounter/starcounter-include#attributeChangedCallback It's just a copy
          */
-        LauncherPartialPrototype.attributeChangedCallback = function(name, oldVal, newVal) {
+        StarcounterIncludePrototype.attributeChangedCallback = function(name, oldVal, newVal) {
             if (name === "partial" || name === "view-model") {
                 this.partial = partialAttributeToProperty(this, newVal);
                 //d console.log("starcounter-partial attr changed");
@@ -149,13 +149,13 @@ version: 2.3.2
          * @see Starcounter/starcounter-include#partialChanged it's alsmost a copy
          * @param  {Object} newVal new partial value
          */
-        LauncherPartialPrototype.partialChanged = function(newVal) {
+        StarcounterIncludePrototype.partialChanged = function(newVal) {
             this._htmlChanged();
             const compositionProvider = this.partial && findCompositionProvider(this.partial);
             this.partialId = compositionProvider && compositionProvider.PartialId; //should always be string
             this._compositionChanged();
         };
-        LauncherPartialPrototype._htmlChanged = function() {
+        StarcounterIncludePrototype._htmlChanged = function() {
             var html = buildURL(this.partial, this.mergedHtmlPrefix, this.defaultHtml);
             if (html !== this._lastHtml) {
                 if (this._lastHtml) {
@@ -175,7 +175,7 @@ version: 2.3.2
                 this.template.model = this.partial
             }
         };
-        LauncherPartialPrototype._compositionChanged = function(composition) {
+        StarcounterIncludePrototype._compositionChanged = function(composition) {
             if (this.partial && composition === undefined) {
                 const compositionProvider = findCompositionProvider(this.partial);
                 if (compositionProvider) {
@@ -203,7 +203,7 @@ version: 2.3.2
          * @param  {String} path Polymer notification path
          * @param  {Mixed} value New value
          */
-        LauncherPartialPrototype._notifyPath = function(path, value) {
+        StarcounterIncludePrototype._notifyPath = function(path, value) {
             if (path.indexOf("partial.") === 0 || path.indexOf("viewModel.") === 0) {
                 if (
                     path === "partial.Html" ||
@@ -274,7 +274,7 @@ version: 2.3.2
          * Saves given or current composition as stored one, (TODO:) notifies binding about it.
          * @param  {String} [compositionStr] composition to be saved, if not given current one will be used
          */
-        LauncherPartialPrototype.saveLayout = function(compositionStr){
+        StarcounterIncludePrototype.saveLayout = function(compositionStr){
             compositionStr = compositionStr || this.compositionElement.shadowRoot.innerHTML;
             this.storedLayout = compositionStr;
             //TODO: trigger polymer-protocol-compliant event
@@ -310,7 +310,7 @@ version: 2.3.2
          * @param  {HTMLElement} node node to select a range, need for Safari workaround
          * @return {DocumentFragment}      parsed string
          */
-        LauncherPartialPrototype.stringToDocumentFragment = function (htmlStr) {
+        StarcounterIncludePrototype.stringToDocumentFragment = function (htmlStr) {
             var range = document.createRange();
             // Safari does not support `createContextualFragment` without selecting a node.
             if (isSafari) {
@@ -337,7 +337,7 @@ version: 2.3.2
         };
 
         document.registerElement('starcounter-include', {
-            prototype: LauncherPartialPrototype
+            prototype: StarcounterIncludePrototype
         });
     })();
 </script>

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -3,7 +3,7 @@
 Custom Element (w/ Polymer's TempalteBinding)
 with predefined template content, which should be used to include partials.
 It's just <template is="imported-template"> wrapped within <juicy-composition> bindable by layout editor.
-Uses juicy-composition.composition given from DB as `Starcounter.MergedPartial.Composition$`.
+Uses juicy-composition.composition given from DB as `Starcounter.MergedPartial.(CompositionProvider|CompositionProvider_0).Composition$`.
 version: 2.3.2
 
 -->
@@ -207,20 +207,25 @@ version: 2.3.2
             if (path.indexOf("partial.") === 0 || path.indexOf("viewModel.") === 0) {
                 if (
                     path === "partial.Html" ||
-                    path.indexOf("partial.LauncherLayoutInfo") === 0 ||
                     // path.match(/^partial\.[^.]+\.Html$/)
                     (path.indexOf('.Html') === path.length - 5) && path.slice(8, -5).indexOf('.') === -1
                 ) {
                     this.partialChanged(this.partial);
                 } else if (
                     path === "viewModel.Html" ||
-                    path.indexOf("viewModel.LauncherLayoutInfo") === 0 ||
                     // path.match(/^viewModel\.[^.]+\.Html$/)
                     (path.indexOf('.Html') === path.length - 5) && path.slice(10, -5).indexOf('.') === -1
                 ) {
                     this.partialChanged(this.partial);
                 } else {
-                    if (this.template._notifyPath) {
+                    const compositionProviderPath = findCompositionProviderPath(this.partial);
+                    if (path === 'partial.' + compositionProviderPath || path === 'viewModel.' + compositionProviderPath) {
+                        // .Composition$ and .PartialId may have changed, also CompositionProvider theoretically could provide it's .Html as well
+                        this.partialChanged();
+                    } else if (path === 'partial.' + compositionProviderPath + '.PartialId' || path === 'viewModel.' + compositionProviderPath + '.PartialId') {
+                        const compositionProvider = findCompositionProvider(this.partial);
+                        this.partialId = compositionProvider && compositionProvider.PartialId; //should always be string
+                    } else if (this.template._notifyPath) {
                         this.template._notifyPath(
                             path.replace("partial.", "model.")
                                 .replace("viewModel.", "model."),
@@ -245,10 +250,6 @@ version: 2.3.2
             if(partial){
                 if(partial.Html !== undefined){
                     return partial.Html;
-                } else if (partial.LauncherLayoutInfo) {
-                    //workaround for https://github.com/StarcounterPrefabs/Launcher/issues/224
-                    //should be removed when the original issue with not patched Html is resolved
-                    return partial.LauncherLayoutInfo.MergedHtml;
                 } else {
                     var htmls = [];
                     for (var key in partial){
@@ -295,7 +296,8 @@ version: 2.3.2
                 findCompositionProvider(this.partial).Composition$ = this.storedLayout;
                 this.dispatchEvent(new CustomEvent("starcounter-include-composition-saved", {detail: this.storedLayout}));
                 // trigger polymer-notification-protocol-compilant event
-                this.dispatchEvent(new CustomEvent("partial-changed", {detail: {value: this.storedLayout, path: 'partial.LauncherLayoutInfo.Composition$'}}));
+                this.dispatchEvent(new CustomEvent("partial-changed", {detail: {value: this.storedLayout, path: 'partial.' + findCompositionProviderPath(this.partial) + '.Composition$'}}));
+                this.dispatchEvent(new CustomEvent("view-model-changed", {detail: {value: this.storedLayout, path: 'viewModel.' + findCompositionProviderPath(this.partial) + '.Composition$'}}));
             }.bind(this);
             return req.send(this.storedLayout);
 
@@ -323,7 +325,15 @@ version: 2.3.2
          * @return {Object}     Composition Provider scope
          */
         function findCompositionProvider(obj) {
-            return obj.LauncherLayoutInfo || obj.CompositionProvider || obj.CompositionProvider_0;
+            return obj.CompositionProvider || obj.CompositionProvider_0;
+        };
+        /**
+         * Find composition provider path in given marged/namespaced view-model
+         * @param  {Object} obj namespaced view-model
+         * @return {String}     path to Composition Provider scope
+         */
+        function findCompositionProviderPath(obj) {
+            return obj.CompositionProvider && 'CompositionProvider'|| obj.CompositionProvider_0 && 'CompositionProvider_0';
         };
 
         document.registerElement('starcounter-include', {

--- a/test/composition/declarative-shadow-dom.html
+++ b/test/composition/declarative-shadow-dom.html
@@ -19,7 +19,7 @@
     <test-fixture id="default-composition">
         <template>
             <starcounter-include partial="{
-                &quot;LauncherLayoutInfo&quot;: {
+                &quot;CompositionProvider&quot;: {
                     &quot;PartialId&quot;: &quot;given PartialId&quot;
                 },
                 &quot;Html&quot;: &quot;../template_w_declarative-shadow-dom.html&quot;,
@@ -38,7 +38,7 @@
 
         var scInclude;
         var partial = {
-            "LauncherLayoutInfo": {
+            "CompositionProvider": {
                 "PartialId": "given PartialId"
             },
             "Html": "../template_w_declarative-shadow-dom.html",

--- a/test/composition/starcounter-composition.html
+++ b/test/composition/starcounter-composition.html
@@ -19,7 +19,7 @@
     <test-fixture id="default-composition">
         <template>
             <starcounter-include partial="{
-                &quot;LauncherLayoutInfo&quot;: {
+                &quot;CompositionProvider&quot;: {
                     &quot;PartialId&quot;: &quot;given PartialId&quot;
                 },
                 &quot;Html&quot;: &quot;../template_w_starcounter-composition.html&quot;,
@@ -38,7 +38,7 @@
 
         var scInclude;
         var partial = {
-            "LauncherLayoutInfo": {
+            "CompositionProvider": {
                 "PartialId": "given PartialId"
             },
             "Html": "../template_w_starcounter-composition.html",

--- a/test/partialAttribute/cleanup_removed_partial_Layout.html
+++ b/test/partialAttribute/cleanup_removed_partial_Layout.html
@@ -28,7 +28,7 @@
             var instance;
             var model = {
                 "Html": "../templateToInclude.html",
-                "LauncherLayoutInfo": {
+                "CompositionProvider": {
                     "Composition$": 'a Composition',
                     "PartialId": "given PartialId"
                 },
@@ -90,7 +90,7 @@
                     expect(instance).to.have.compositionAttached;
                     instance.partial = {
                         "Html": "../templateToInclude.html",
-                        "LauncherLayoutInfo": {
+                        "CompositionProvider": {
                             "Composition$": "",
                             "PartialId": ""
                         },

--- a/test/partialAttribute/cleanup_removed_partial_PartialId.html
+++ b/test/partialAttribute/cleanup_removed_partial_PartialId.html
@@ -29,7 +29,7 @@
             var instance;
             var model = {
                 "Html": "../templateToInclude.html",
-                "LauncherLayoutInfo": {
+                "CompositionProvider": {
                     "PartialId": "templateToInclude.html"
                 },
                 "doesItWork": "works!"
@@ -90,7 +90,7 @@
                     expectPartialToBeAttached();
                     instance.partial = {
                         "Html": "../templateToInclude.html",
-                        "LauncherLayoutInfo": {
+                        "CompositionProvider": {
                             "PartialId": ""
                         },
                         "doesItWork": "works!"
@@ -101,8 +101,8 @@
             });
 
             function expectPartialToBeAttached() {
-                expect(instance).to.have.HTMLAttribute('partial-id').equal(model.LauncherLayoutInfo.PartialId);
-                expect(instance.partialId).to.be.equal(model.LauncherLayoutInfo.PartialId);
+                expect(instance).to.have.HTMLAttribute('partial-id').equal(model.CompositionProvider.PartialId);
+                expect(instance.partialId).to.be.equal(model.CompositionProvider.PartialId);
             }
 
             function expectPartialToBeCleanedUp() {

--- a/test/partialId-property/reflect-partialId-to-attribute.html
+++ b/test/partialId-property/reflect-partialId-to-attribute.html
@@ -21,7 +21,7 @@
             <!-- nest to workaround test-fixture bug -->
             <div>
                 <starcounter-include partial="{
-                    &quot;LauncherLayoutInfo&quot;: {
+                    &quot;CompositionProvider&quot;: {
                         &quot;PartialId&quot;: &quot;given PartialId&quot;
                     },
                     &quot;Html&quot;: &quot;../templateToInclude.html&quot;,
@@ -50,17 +50,17 @@
             </div>
         </template>
     </test-fixture>
-    <test-fixture id="no-LauncherLayoutInfo">
+    <test-fixture id="no-CompositionProvider">
         <template>
             <div>
                 <starcounter-include partial="{&quot;Html&quot;: &quot;../templateToInclude.html&quot;, &quot;doesItWork&quot;: &quot;worked!&quot;}"></starcounter-include>
             </div>
         </template>
     </test-fixture>
-    <test-fixture id="no-LauncherLayoutInfo.PartialId">
+    <test-fixture id="no-CompositionProvider.PartialId">
         <template>
             <div>
-                <starcounter-include partial="{&quot;Html&quot;: &quot;../old_templateToInclude.html&quot;, &quot;doesItWork&quot;: &quot;worked!&quot;, &quot;LauncherLayoutInfo&quot;: {}}"></starcounter-include>
+                <starcounter-include partial="{&quot;Html&quot;: &quot;../old_templateToInclude.html&quot;, &quot;doesItWork&quot;: &quot;worked!&quot;, &quot;CompositionProvider&quot;: {}}"></starcounter-include>
             </div>
         </template>
     </test-fixture>
@@ -68,7 +68,7 @@
         <template>
             <div>
                 <starcounter-include partial="{
-                    &quot;LauncherLayoutInfo&quot;: {
+                    &quot;CompositionProvider&quot;: {
                         &quot;PartialId&quot;: &quot;old PartialId&quot;,
                     },
                     &quot;Html&quot;: &quot;../templateToInclude.html&quot;,
@@ -83,7 +83,7 @@
         var scInclude;
         function getFullPartial() {
           return {
-              "LauncherLayoutInfo": {
+              "CompositionProvider": {
                   "PartialId": "given PartialId"
               },
               "Html": "../templateToInclude.html",
@@ -92,7 +92,7 @@
         }
         function getNewPartial() {
           return {
-            "LauncherLayoutInfo": {
+            "CompositionProvider": {
                 "PartialId": "new PartialId"
             },
             "Html": "../templateToInclude.html",
@@ -123,7 +123,7 @@
             expect(scInclude).to.have.HTMLAttribute('partial-id').equal('new PartialId');
         });
 
-        it('when it was set, then changed with Polymer dom-bind (`LauncherLayoutInfo` object), should reflect this change', function (done) {
+        it('when it was set, then changed with Polymer dom-bind (`CompositionProvider` object), should reflect this change', function (done) {
             var domBind;
             container = fixture('dom-bind');
             domBind = container.querySelector('[is="dom-bind"]');
@@ -135,7 +135,7 @@
                 expect(scInclude).to.have.HTMLAttribute('partial-id').equal('given PartialId');
 
                 // change .PartialId
-                domBind.set('partial.LauncherLayoutInfo', {PartialId: "new PartialId"});
+                domBind.set('partial.CompositionProvider', {PartialId: "new PartialId"});
                 setTimeout(function oncePolymerNotificationPropagated() {
                     expect(scInclude.partialId).to.equal('new PartialId');
                     expect(scInclude).to.have.HTMLAttribute('partial-id').equal('new PartialId');
@@ -144,7 +144,7 @@
             }, 100);
         });
 
-        it('when it was set, then changed with Polymer dom-bind (just `LauncherLayoutInfo.PartialId` property), should reflect this change', function (done) {
+        it('when it was set, then changed with Polymer dom-bind (just `CompositionProvider.PartialId` property), should reflect this change', function (done) {
             var domBind;
             container = fixture('dom-bind');
             domBind = container.querySelector('[is="dom-bind"]');
@@ -156,7 +156,7 @@
                 expect(scInclude).to.have.HTMLAttribute('partial-id').equal('given PartialId');
 
                 // change .PartialId
-                domBind.set('partial.LauncherLayoutInfo.PartialId', 'new PartialId');
+                domBind.set('partial.CompositionProvider.PartialId', 'new PartialId');
                 setTimeout(function oncePolymerNotificationPropagated() {
                     expect(scInclude.partialId).to.equal('new PartialId');
                     expect(scInclude).to.have.HTMLAttribute('partial-id').equal('new PartialId');


### PR DESCRIPTION
As agreed with @warpech at #34, we will no longer support `LauncherLayoutInfo`
Plus, add support for view-model-changed event

 - #30
 - #34

I would bump at least minor version after this is merged.