### PR TITLE
Ignore `_ver#s` and `_ver#c$` properties

### DIFF
--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -254,11 +254,15 @@ version: 2.4.0
                     var htmls = [];
                     for (var key in partial){
                         if (partial.hasOwnProperty(key)) {
-                            htmls.push(
-                                encodeURIComponent(key) +
-                                '=' +
-                                (partial[key].Html && encodeURIComponent(partial[key].Html) || defaultURL)
-                            );
+                            // quick fix for https://github.com/Starcounter/starcounter-include/issues/37
+                            // just to unblock https://github.com/Starcounter/level1/issues/4061
+                            if(key !== '_ver#s' && key !== '_ver#c$'){
+                                htmls.push(
+                                    encodeURIComponent(key) +
+                                    '=' +
+                                    (partial[key].Html && encodeURIComponent(partial[key].Html) || defaultURL)
+                                );
+                            }
                         }
                     }
                     // Workaround for https://github.com/Starcounter/Starcounter/issues/3072

--- a/test/internals/buildURL.html
+++ b/test/internals/buildURL.html
@@ -44,6 +44,25 @@
             });
         });
 
+        it('should ignore `_ver#s` and `_ver#c$` properties', function (done) {
+            scInclude = document.createElement('starcounter-include');
+            let clonedModel = clone(model);
+            clonedModel['_ver#s'] = 10;
+            clonedModel['_ver#c$'] = 77;
+            scInclude.partial = clonedModel;
+            let importedTemplate = scInclude.querySelector_template_for_buggy_polyfill();
+
+            expect(importedTemplate.getAttribute("content")).to.equal('/sc/htmlmerger?scope%3B%2C%2F%3F%3A%40%26%3D%2B%24=scopeHtml%3B%2C%2F%3F%3A%40%26%3D%2B%24');
+            expect(importedTemplate.model).to.equal(null);
+
+            document.body.appendChild(scInclude);
+
+            importedTemplate.addEventListener('stamping', function onceStamped(){
+                expect(importedTemplate.model).to.equal(scInclude.partial);
+                done();
+            });
+        });
+
     });
     function clone(obj) {
         return JSON.parse(JSON.stringify(obj));


### PR DESCRIPTION
while building merged HTML URL

quick fix for ignoring Palindrom meta data https://github.com/Starcounter/starcounter-include/issues/37