### PR TITLE
CEv1+remove `juicy-composition`

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Or [download as ZIP](https://github.com/Starcounter/starcounter-include/archive/
 
     ```html
     <script src="bower_components/webcomponentsjs/webcomponents.js"></script>
+    <script src="bower_components/document-register-element/build/document-register-element.js"></script>
     ```
 
 2. Import Custom Element:

--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,8 @@
     "starcounter",
     "web-components",
     "include",
+    "shadow-dom",
+    "distribution",
     "imported-template"
   ],
   "license": "MIT",
@@ -28,10 +30,11 @@
   ],
   "dependencies": {
     "imported-template": ">=1.4.4",
-    "juicy-composition": ">=0.0.7"
+    "translate-shadowdom": ">=0.0.4"
   },
   "devDependencies": {
-    "web-component-tester": "Polymer/web-component-tester#>=5.0.0",
-    "polymer": "^1.9.1"
+    "web-component-tester": ">=5.0.0",
+    "polymer": "^1.9.1",
+    "document-register-element": "^1.5.0"
   }
 }

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -262,9 +262,15 @@ version: 2.4.1
                     this.partialChanged(this.partial);
                 } else {
                     const compositionProviderPath = findCompositionProviderPath(this.partial);
-                    if (path === 'partial.' + compositionProviderPath || path === 'viewModel.' + compositionProviderPath) {
+                    if (path === 'partial.' + compositionProviderPath ||
+                        path === 'viewModel.' + compositionProviderPath) {
                         // .Composition$ and .PartialId may have changed, also CompositionProvider theoretically could provide it's .Html as well
                         this.partialChanged();
+                    } else if(
+                    path === 'partial.' + compositionProviderPath  + '.Composition$'||
+                        path === 'viewModel.' + compositionProviderPath + '.Composition$') {
+                        // .Composition$ have changed
+                        this._compositionChanged();
                     } else if (path === 'partial.' + compositionProviderPath + '.PartialId' || path === 'viewModel.' + compositionProviderPath + '.PartialId') {
                         const compositionProvider = findCompositionProvider(this.partial);
                         this.partialId = compositionProvider && compositionProvider.PartialId; //should always be string
@@ -392,7 +398,7 @@ version: 2.4.1
          * @param {DocumentFragment} givenComposition
          */
         StarcounterIncludePrototype.stampComposition = function(givenComposition){
-            console.log('stamp', this.partialId, this);
+            // console.log('stamp', this.partialId, this);
             // document.importNode(givenComposition, true);
             // create shadowRoot if none
             const shadowRoot = this.shadowRoot;

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -2,28 +2,92 @@
 `starcounter-include` -
 Custom Element (w/ Polymer's TemplateBinding)
 with predefined template content, which should be used to include partials.
-It's just <template is="imported-template"> wrapped within <juicy-composition> bindable by layout editor.
-Uses juicy-composition.composition given from DB as `Starcounter.MergedPartial.(CompositionProvider|CompositionProvider_0).Composition$`.
+It's just <template is="imported-template"> wrapped within Shadow Root for `declarative-shadow-dom` bindable by layout editor.
+Uses Shadow DOM given from DB as `Starcounter.MergedPartial.(CompositionProvider|CompositionProvider_0).Composition$`.
 version: 2.3.2
 
 -->
 <!-- Import dependencies -->
 <link rel="import" href="../imported-template/imported-template.html">
-<link rel="import" href="../juicy-composition/juicy-composition.html">
+<link rel="import" href="../translate-shadowdom/translate-shadowdom.html">
 <!-- <link rel="import" href="/sys/console-log/console-log.html"> -->
 
-<template id="partial-template">
-    <juicy-composition auto-stamp>
-        <template is="imported-template"></template>
-    </juicy-composition>
-</template>
 <script>
     (function() {
+        const useShadowDOMV1 = Boolean(Element.prototype.attachShadow && Node.prototype.getRootNode);
+        // && !(window.StarcounterInclude && window.StarcounterInclude.shadow === 'v0'));
+        const defaultShadowCSS = '<style>:host{display:block;}</style>';
+        const defaultShadowDOM = useShadowDOMV1 ? '<slot></slot>' : '<content></content>';
 
-        var isSafari = navigator.vendor && navigator.vendor.indexOf("Apple") > -1 && navigator.userAgent && !navigator.userAgent.match("CriOS");
 
-        var templ = (document._currentScript || document.currentScript).ownerDocument.getElementById("partial-template");
-        var StarcounterIncludePrototype = Object.create(HTMLElement.prototype);
+        const isSafari = navigator.vendor && navigator.vendor.indexOf("Apple") > -1 && navigator.userAgent && !navigator.userAgent.match("CriOS");
+
+        class StarcounterInclude extends HTMLElement {
+            // static get shadow(){
+            //     return useShadowDOMV1;
+            // }
+            static get observedAttributes() {
+                return ['partial', 'view-model', 'partialId'];
+            }
+            // the self argument might be provided or not
+            // in both cases, the mandatory `super()` call
+            // will return the right context/instance to use
+            // and eventually return
+            constructor(self) {
+                self = super(self);
+                self.created();
+                return self;
+            }
+            /**
+             * Stamp `imported-template` into Light DOM,
+             * attach `stamping` listener to gather Shadow DOM layout compositions
+             * (declarative-shadow-dom)
+             */
+            stampImportedTemplate(){
+                if(!this.template){
+                    const starcounterInclude = this;
+                    const importedTemplate = document.createElement('template', 'imported-template');
+
+                    var partial = partialAttributeToProperty(this);
+                    if(partial === undefined && this.partial){
+                        partial = this.partial;
+                    }
+                    var html = buildURL(partial, this.mergedHtmlPrefix, this.defaultHtml);
+
+                    importedTemplate.addEventListener('stamping', function fetchCompositions(event) {
+                        var mergedComposition;
+                        var templates = event.detail.querySelectorAll('template[is="declarative-shadow-dom"],template[is="starcounter-composition"]');
+                        if(templates.length){
+                            mergedComposition = document.createDocumentFragment()
+                            Array.prototype.forEach.call(templates, function mergeContents(individualComposition) {
+                                if(individualComposition.getAttribute('is') === 'starcounter-composition'){
+                                    console.warn('`starcounter-composition` was renamed to `declarative-shadow-dom`! Please update your markup, as the old name is likely to be not supported soon (in V1).')
+                                }
+                                mergedComposition.appendChild(individualComposition.content);
+                            });
+                        }
+                        starcounterInclude.defaultComposition = mergedComposition;
+
+                        if (this.model != starcounterInclude.partial) {
+                            this.model = starcounterInclude.partial
+                        }
+                        // notify composition property
+                        // TODO: consider moving entire partialChanged or appendChild here
+                        starcounterInclude._compositionChanged();
+                    });
+                    html && importedTemplate.setAttribute('content', html);
+
+
+                    this.appendChild(importedTemplate);
+                    this.template = importedTemplate;
+                }
+            }
+            connectedCallback(){
+                this.stampImportedTemplate();
+            }
+        }
+        var StarcounterIncludePrototype = StarcounterInclude.prototype;
+        StarcounterIncludePrototype.shadow = useShadowDOMV1;
         StarcounterIncludePrototype.partial = null;
         StarcounterIncludePrototype.partialId = null;
         //FIXME: this one should not be needed, once we get rid of workarounds for server-side
@@ -46,50 +110,21 @@ version: 2.3.2
             }
         }
         /**
-         * Use predefined template content, rewrite attributes.
+         * Create shadowRoot, define property setters, set unitial partial.
          */
-        StarcounterIncludePrototype.createdCallback = function LPartialCreated() {
-            // ugly https://code.google.com/p/chromium/issues/detail?id=430578 workaround
-            // if( inDocumentFragment( this ) ){
-            //   return ;
-            // }
-            var partial = partialAttributeToProperty(this);
-            if(partial === undefined && this.partial){
-                partial = this.partial;
-            }
-            var html = buildURL(partial, this.mergedHtmlPrefix, this.defaultHtml);
+        StarcounterIncludePrototype.created = function StarcounterIncludeCreated() {
             var starcounterInclude = this;
             var partialId = this.partialId;
+            var partial = this.partial;
+
             // build shadow DOM
-            var sroot = this.createShadowRoot();
-            sroot.innerHTML = "<style>:host{display:block;}</style><content></content>";
-
-            var clone = document.importNode(templ.content, true);
-            this.compositionElement = clone.children[0]; // .getElementsByTagName("juicy-composition");
-            this.template = this.compositionElement.firstElementChild; // .getElementsByTagName("TEMPLATE");
-
-            this.template.addEventListener('stamping', function fetchCompositions(event) {
-                var mergedComposition;
-                var templates = event.detail.querySelectorAll('template[is="declarative-shadow-dom"],template[is="starcounter-composition"]');
-                if(templates.length){
-                    mergedComposition = document.createDocumentFragment()
-                    Array.prototype.forEach.call(templates, function mergeContents(individualComposition) {
-                        if(individualComposition.getAttribute('is') === 'starcounter-composition'){
-                            console.warn('`starcounter-composition` was renamed to `declarative-shadow-dom`! Please update your markup, as the old name is likely to be not supported soon (in V1).')
-                        }
-                        mergedComposition.appendChild(individualComposition.content);
-                    });
-                }
-                starcounterInclude.defaultComposition = mergedComposition;
-
-                if (this.model != starcounterInclude.partial) {
-                    this.model = starcounterInclude.partial
-                }
-                // notify composition property
-                // TODO: consider moving entire partialChanged or appendChild here
-                starcounterInclude._compositionChanged();
-            });
-            html && this.template.setAttribute('content', html);
+            if(useShadowDOMV1){
+                this.attachShadow({mode: "open"});
+            } else {
+                this.createShadowRoot();
+            }
+            // partialChanged will do
+            // this.stampComposition();
 
             // define a setter for partial attribute,
             // so it could be change by VanillaJs without Polymer Template Binding
@@ -97,6 +132,7 @@ version: 2.3.2
                 partial: {
                     set: function(newValue) {
                         partial = newValue;
+                        starcounterInclude.stampImportedTemplate();
                         starcounterInclude.partialChanged(partial);
                     },
                     get: function() {
@@ -117,10 +153,8 @@ version: 2.3.2
                         if (newValue != partialId) {
                             partialId = newValue || null;
                             if (!partialId) {
-                                // this.compositionElement.removeAttribute("name");
                                 this.removeAttribute("partial-id");
                             } else {
-                                // this.compositionElement.setAttribute("name", partialId);
                                 this.setAttribute("partial-id", partialId);
                             }
                         }
@@ -132,11 +166,9 @@ version: 2.3.2
             });
             // attach partial
             this.partialChanged();
-            // attach to light DOM
-            this.appendChild(clone);
         };
         /**
-         * @see Starcounter/starcounter-include#attributeChangedCallback It's just a copy
+         * Set partial property if partial or viewm-model attribute was changed
          */
         StarcounterIncludePrototype.attributeChangedCallback = function(name, oldVal, newVal) {
             if (name === "partial" || name === "view-model") {
@@ -156,6 +188,10 @@ version: 2.3.2
             this._compositionChanged();
         };
         StarcounterIncludePrototype._htmlChanged = function() {
+            // do nothing if there is no tempalte yet
+            if(!this.template){
+                return;
+            }
             var html = buildURL(this.partial, this.mergedHtmlPrefix, this.defaultHtml);
             if (html !== this._lastHtml) {
                 if (this._lastHtml) {
@@ -175,26 +211,33 @@ version: 2.3.2
                 this.template.model = this.partial
             }
         };
-        StarcounterIncludePrototype._compositionChanged = function(composition) {
-            if (this.partial && composition === undefined) {
+        /**
+         * Handles change of the composition.
+         * If not given explicitely, fetches one from provider.
+         * Stamps if needed.
+         * @see .stampComposition
+         * @param  {String} compositionString stringified HTML for new Shadow Root
+         */
+        StarcounterIncludePrototype._compositionChanged = function(compositionString) {
+            let composition;
+            if (this.partial && compositionString === undefined) {
                 const compositionProvider = findCompositionProvider(this.partial);
                 if (compositionProvider) {
-                    composition = compositionProvider.Composition$; //should always be string
+                    compositionString = compositionProvider.Composition$; //should always be string
+                    this.storedLayout = compositionString;
                 }
             }
             // do not change if there is one, it's same as before, and we are not forced
-            if (!composition || composition !== this._lastLayout || this._forceLayoutChange) {
-                if (!composition) {
-                    this.storedLayout = null;
-                    this.compositionElement.composition = this.defaultComposition && this.defaultComposition.cloneNode(true);
-                    // this.compositionElement.composition = '<div style="min-width: 1200px;"><content></content></div>';
+            if (!compositionString || compositionString !== this._lastLayout || this._forceLayoutChange) {
+                if (!compositionString) {
+                    composition = this.defaultComposition && this.defaultComposition.cloneNode(true);
                 } else {
-                    this.storedLayout = composition;
                     // make clone to avoid direct binding
-                    this.compositionElement.composition = this.stringToDocumentFragment(composition);
+                    composition = this.stringToDocumentFragment(compositionString);
                 }
+                this.stampComposition(composition);
                 this._forceLayoutChange = false;
-                this._lastLayout = composition;
+                this._lastLayout = compositionString;
             }
         };
         /**
@@ -273,9 +316,10 @@ version: 2.3.2
         /**
          * Saves given or current composition as stored one, (TODO:) notifies binding about it.
          * @param  {String} [compositionStr] composition to be saved, if not given current one will be used
+         * @TODO: to be simplified after https://github.com/StarcounterApps/CompositionProvider/pull/13 is done
          */
         StarcounterIncludePrototype.saveLayout = function(compositionStr){
-            compositionStr = compositionStr || this.compositionElement.shadowRoot.innerHTML;
+            compositionStr = compositionStr || this.shadowRoot.innerHTML;
             this.storedLayout = compositionStr;
             //TODO: trigger polymer-protocol-compliant event
 
@@ -286,10 +330,10 @@ version: 2.3.2
             req.onreadystatechange = function () {
                 if (req.readyState == 4) {
                     if (!(req.status >= 200 && req.status <= 299)) {
-                        console.error("Failed to save juicy-tile-list configuration");
+                        console.error("Failed to save composition configuration");
                         return;
                     }
-                    console.info("juicy-composition configuration saved");
+                    console.info("composition configuration saved");
                 }
                 // FIXME: bellow is required for save button not to overwrite with old value, but it fails due to puppet error
                 console.info('Direct change to model is required for save button not to overwrite with old value, but it fails due to puppet error.');
@@ -336,8 +380,43 @@ version: 2.3.2
             return obj.CompositionProvider && 'CompositionProvider'|| obj.CompositionProvider_0 && 'CompositionProvider_0';
         };
 
-        document.registerElement('starcounter-include', {
-            prototype: StarcounterIncludePrototype
-        });
+
+        /**
+         * Stamps new shadow root (overwrites existing),
+         * translates between V1 and V0
+         * @fires stamped
+         * @param {DocumentFragment} givenComposition
+         */
+        StarcounterIncludePrototype.stampComposition = function(givenComposition){
+            console.log('stamp', this.partialId, this);
+            // document.importNode(givenComposition, true);
+            // create shadowRoot if none
+            const shadowRoot = this.shadowRoot;
+
+            if (givenComposition) {
+                // reset SD to default CSS
+                shadowRoot.innerHTML = '';
+                if(useShadowDOMV1){
+                    // translate givenComposition to current version of SD
+                    TranslateShadowDOM.v0tov1.fragment(givenComposition, true);
+                } else {
+                    // translate givenComposition to current version of SD
+                    TranslateShadowDOM.v1tov0.fragment(givenComposition, true);
+                }
+
+                shadowRoot.appendChild(givenComposition);
+                this.isStamped = true;
+            } else if(shadowRoot){
+                shadowRoot.innerHTML = defaultShadowCSS + defaultShadowDOM;
+            }
+            this.dispatchEvent(new CustomEvent("stamped"));
+        }
+
+        StarcounterIncludePrototype.clear = function (){
+            console.error('clear is not yet defined!');
+        }
+
+
+        customElements.define('starcounter-include', StarcounterInclude);
     })();
 </script>

--- a/test/composition/declarative-shadow-dom.html
+++ b/test/composition/declarative-shadow-dom.html
@@ -8,6 +8,7 @@
         window.JuicyComposition = {shadow: 'v0'};
     </script>
     <script src="../../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../../document-register-element/build/document-register-element.js"></script>
     <script src="../../../web-component-tester/browser.js"></script>
     <script src="../helpers/chainable-methods-for-partial.js"></script>
 
@@ -29,12 +30,18 @@
     </test-fixture>
     <template id="reference-composition">
         <h2>Custom Shadow DOM composition</h2>
-		<content select='[slot="my-slot"]'></content>
+		<slot name="my-slot"></slot>
+    </template>
+    <template id="reference-composition-v1-to-v0">
+        <h2>Custom Shadow DOM composition</h2>
+		<content name="my-slot" select="[slot='my-slot']"></content>
     </template>
 
 
     <script>
     describe('starcounter-include when imports a template that contains <code>template is="declarative-shadow-dom"</code>', function () {
+        const useShadowDOMV1 = Boolean(Element.prototype.attachShadow && Node.prototype.getRootNode);
+        const REFERENCE_COMPOSITION = useShadowDOMV1 ? '#reference-composition' : '#reference-composition-v1-to-v0'
 
         var scInclude;
         var partial = {
@@ -54,10 +61,9 @@
             setTimeout(done, 500);
         });
         it('should use it as it\'s composition', function () {
-            expect(document.querySelector('juicy-composition')).to.be.not.null;
-            expect(document.querySelector('juicy-composition').composition).to.be.not.null;
-            expect(document.querySelector('juicy-composition').composition.innerHTML.trim()).to.be
-                .equal(document.querySelector('#reference-composition').innerHTML.trim());
+            expect(scInclude.shadowRoot).to.be.not.null;
+            expect(scInclude.shadowRoot.innerHTML.trim()).to.be
+                .equal(document.querySelector(REFERENCE_COMPOSITION).innerHTML.trim());
         });
         describe('after partial property is replaced with the partial that also does contain default composition', function () {
             beforeEach(function (done) {
@@ -65,10 +71,9 @@
                 setTimeout(done, 500);
             });
             it('should use it as it\'s composition', function () {
-                expect(document.querySelector('juicy-composition')).to.be.not.null;
-                expect(document.querySelector('juicy-composition').composition).to.be.not.null;
-                expect(document.querySelector('juicy-composition').composition.innerHTML.trim()).to.be
-                    .equal(document.querySelector('#reference-composition').innerHTML.trim());
+                expect(scInclude.shadowRoot).to.be.not.null;
+                expect(scInclude.shadowRoot.innerHTML.trim()).to.be
+                    .equal(document.querySelector(REFERENCE_COMPOSITION).innerHTML.trim());
             });
         });
 

--- a/test/composition/starcounter-composition.html
+++ b/test/composition/starcounter-composition.html
@@ -8,6 +8,7 @@
         window.JuicyComposition = {shadow: 'v0'};
     </script>
     <script src="../../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../../document-register-element/build/document-register-element.js"></script>
     <script src="../../../web-component-tester/browser.js"></script>
     <script src="../helpers/chainable-methods-for-partial.js"></script>
 
@@ -29,12 +30,18 @@
     </test-fixture>
     <template id="reference-composition">
         <h2>Custom Shadow DOM composition</h2>
-		<content select='[slot="my-slot"]'></content>
+		<slot name="my-slot"></slot>
+    </template>
+    <template id="reference-composition-v1-to-v0">
+        <h2>Custom Shadow DOM composition</h2>
+		<content name="my-slot" select="[slot='my-slot']"></content>
     </template>
 
 
     <script>
     describe('starcounter-include when imports a template that contains <code>template is="starcounter-composition"</code>', function () {
+        const useShadowDOMV1 = Boolean(Element.prototype.attachShadow && Node.prototype.getRootNode);
+        const REFERENCE_COMPOSITION = useShadowDOMV1 ? '#reference-composition' : '#reference-composition-v1-to-v0'
 
         var scInclude;
         var partial = {
@@ -56,10 +63,9 @@
             setTimeout(done, 500);
         });
         it('should use it as it\'s composition', function () {
-            expect(document.querySelector('juicy-composition')).to.be.not.null;
-            expect(document.querySelector('juicy-composition').composition).to.be.not.null;
-            expect(document.querySelector('juicy-composition').composition.innerHTML.trim()).to.be
-                .equal(document.querySelector('#reference-composition').innerHTML.trim());
+            expect(scInclude.shadowRoot).to.be.not.null;
+            expect(scInclude.shadowRoot.innerHTML.trim()).to.be
+                .equal(document.querySelector(REFERENCE_COMPOSITION).innerHTML.trim());
         });
         it('should call console warn with new name', function () {
             expect(console.warn).to.be.called;
@@ -71,10 +77,9 @@
                 setTimeout(done, 500);
             });
             it('should use it as it\'s composition', function () {
-                expect(document.querySelector('juicy-composition')).to.be.not.null;
-                expect(document.querySelector('juicy-composition').composition).to.be.not.null;
-                expect(document.querySelector('juicy-composition').composition.innerHTML.trim()).to.be
-                    .equal(document.querySelector('#reference-composition').innerHTML.trim());
+                expect(scInclude.shadowRoot).to.be.not.null;
+                expect(scInclude.shadowRoot.innerHTML.trim()).to.be
+                    .equal(document.querySelector(REFERENCE_COMPOSITION).innerHTML.trim());
             });
         });
 

--- a/test/helpers/WCT-Polyfill_bugs_workaround.js
+++ b/test/helpers/WCT-Polyfill_bugs_workaround.js
@@ -1,3 +1,3 @@
 HTMLElement.prototype.querySelector_template_for_buggy_polyfill = function querySelector_template_for_buggy_polyfill(){
-    return this.querySelector('juicy-composition').firstElementChild;
+    return this.firstElementChild;
 };

--- a/test/index.html
+++ b/test/index.html
@@ -1,40 +1,64 @@
 <!doctype html>
 <html>
-  <head>
+
+<head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
     <script src="../../webcomponentsjs/webcomponents.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
+</head>
 
-  </head>
-  <body>
+<body>
     <script>
-      // Load and run all tests (.html, .js):
-      WCT.loadSuites([
-        'partialAttribute/not_provided.html',
-        'partialAttribute/given_in_HTML.html',
-        'partialAttribute/given_in_JS.html',
-        'partialAttribute/given_in_JS_before_upgrade.html',
-        'partialAttribute/not_stamped_from_polymer_template.html',
-        'partialAttribute/stamped_from_polymer_template.html',
-        'partialAttribute/cleanup_removed_partial_Html.html',
-        'partialAttribute/cleanup_removed_partial_PartialId.html',
-        'partialAttribute/cleanup_removed_partial_Layout.html',
-        // {} -> null workaround
-        'partialAttribute/set_to_empty_object.html',
-        // scoped partials
-        'partialAttribute/nested-html/given_in_HTML.html',
-        'partialAttribute/nested-html/given_in_JS.html',
-        'partialAttribute/nested-html/stamped_from_polymer_template.html',
-        // partialId reflection
-        'partialId-property/reflect-partialId-to-attribute.html',
-        // compositions
-        'composition/declarative-shadow-dom.html',
-        'composition/starcounter-composition.html',
-        //internals
-        'internals/buildURL.html'
-      ]);
+        // Load and run all tests (.html, .js):
+        var suites = [
+            'partialAttribute/not_provided.html',
+            'partialAttribute/given_in_HTML.html',
+            'partialAttribute/given_in_JS.html',
+            'partialAttribute/given_in_JS_before_upgrade.html',
+            'partialAttribute/not_stamped_from_polymer_template.html',
+            'partialAttribute/stamped_from_polymer_template.html',
+            'partialAttribute/cleanup_removed_partial_Html.html',
+            'partialAttribute/cleanup_removed_partial_PartialId.html',
+            'partialAttribute/cleanup_removed_partial_Layout.html',
+            // {} -> null workaround
+            'partialAttribute/set_to_empty_object.html',
+            // scoped partials
+            'partialAttribute/nested-html/given_in_HTML.html',
+            'partialAttribute/nested-html/given_in_JS.html',
+            'partialAttribute/nested-html/stamped_from_polymer_template.html',
+            // partialId reflection
+            'partialId-property/reflect-partialId-to-attribute.html',
+            // compositions
+            'composition/declarative-shadow-dom.html',
+            'composition/starcounter-composition.html',
+            //internals
+            'internals/buildURL.html'
+        ];
+        var v0suites = [
+            'v0/basic.html',
+            'v0/translate/v1-to-v0.html', // translate between v0 and v1
+            'v0/smoke/webcomponents-webcomponentsjs-issues-648.html' // add missing slots
+        ];
+        var v1suites = [
+            'v1/basic.html',
+            'v1/translate/v0-to-v1.html', // translate between v0 and v1
+            'v1/smoke/webcomponents-webcomponentsjs-issues-648.html' // add missing slots
+        ];
+        // in v1 environment
+        if (Element.prototype.attachShadow && Node.prototype.getRootNode) {
+            // test also forced v0
+            // v0suites = v0suites.map(function(url) {
+            //     return url + '?juicy-composition-shadow=v0'
+            // });
+            suites = suites.concat(v1suites);
+        } else {
+            suites = suites.concat(v0suites);
+        }
+        WCT.loadSuites(suites);
+
     </script>
-  </body>
+</body>
+
 </html>

--- a/test/internals/buildURL.html
+++ b/test/internals/buildURL.html
@@ -7,6 +7,7 @@
 
     <script src="../../../web-component-tester/browser.js"></script>
     <script src="../../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../../document-register-element/build/document-register-element.js"></script>
 
     <!-- Step 1: import the element to test -->
     <link rel="import" href="../../starcounter-include.html">

--- a/test/partialAttribute/cleanup_removed_partial_Html.html
+++ b/test/partialAttribute/cleanup_removed_partial_Html.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
     <script src="../../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../../document-register-element/build/document-register-element.js"></script>
     <script src="../../../web-component-tester/browser.js"></script>
 
     <link rel="import" href="../../starcounter-include.html">

--- a/test/partialAttribute/cleanup_removed_partial_Layout.html
+++ b/test/partialAttribute/cleanup_removed_partial_Layout.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
     <script src="../../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../../document-register-element/build/document-register-element.js"></script>
     <script src="../../../web-component-tester/browser.js"></script>
 
     <link rel="import" href="../../starcounter-include.html">
@@ -20,6 +21,8 @@
     </test-fixture>
 
     <script>
+        const useShadowDOMV1 = Boolean(Element.prototype.attachShadow && Node.prototype.getRootNode);
+        const DEFAULT_COMPOSITION = useShadowDOMV1 ? '<style>:host{display:block;}</style><slot></slot>' : '<style>:host{display:block;}</style><content></content>';
         describe('cleanup changes of Composition$', function() {
             afterEach(function (done) {
                 // give more time to polyfill cleanup
@@ -107,12 +110,13 @@
         });
         chai.Assertion.addProperty('compositionAttached', function () {
           var obj = chai.util.flag(this, 'object');
-          new chai.Assertion(obj.compositionElement.composition).to.be.instanceof(DocumentFragment);
+          new chai.Assertion(obj.shadowRoot).to.be.instanceof(DocumentFragment);
+          new chai.Assertion(obj.shadowRoot.innerHTML).to.be.ok;
         });
         chai.Assertion.addProperty('compositionCleanedUp', function () {
           var obj = chai.util.flag(this, 'object');
-          new chai.Assertion(obj.compositionElement).to.be.instanceof(HTMLElement);
-          new chai.Assertion(obj.compositionElement.shadowRoot.innerHTML).to.equal('');
+          new chai.Assertion(obj).to.be.instanceof(HTMLElement);
+          new chai.Assertion(obj.shadowRoot.innerHTML).to.equal(DEFAULT_COMPOSITION);
         });
     </script>
 

--- a/test/partialAttribute/cleanup_removed_partial_PartialId.html
+++ b/test/partialAttribute/cleanup_removed_partial_PartialId.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
     <script src="../../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../../document-register-element/build/document-register-element.js"></script>
     <script src="../../../web-component-tester/browser.js"></script>
     <script src="../helpers/chainable-methods-for-partial.js"></script>
 

--- a/test/partialAttribute/given_in_HTML.html
+++ b/test/partialAttribute/given_in_HTML.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
     <script src="../../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../../document-register-element/build/document-register-element.js"></script>
     <script src="../../../web-component-tester/browser.js"></script>
     <script src="../helpers/chainable-methods-for-partial.js"></script>
 

--- a/test/partialAttribute/given_in_JS.html
+++ b/test/partialAttribute/given_in_JS.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
     <script src="../../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../../document-register-element/build/document-register-element.js"></script>
     <script src="../../../web-component-tester/browser.js"></script>
     <script src="../helpers/chainable-methods-for-partial.js"></script>
 

--- a/test/partialAttribute/given_in_JS_before_upgrade.html
+++ b/test/partialAttribute/given_in_JS_before_upgrade.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
     <script src="../../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../../document-register-element/build/document-register-element.js"></script>
     <script src="../../../web-component-tester/browser.js"></script>
     <script src="../helpers/chainable-methods-for-partial.js"></script>
 

--- a/test/partialAttribute/nested-html/given_in_HTML.html
+++ b/test/partialAttribute/nested-html/given_in_HTML.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
     <script src="../../../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../../../document-register-element/build/document-register-element.js"></script>
     <script src="../../../../web-component-tester/browser.js"></script>
 
     <!-- Step 1: import the element to test -->
@@ -78,6 +79,7 @@
                     scInclude.setAttribute('partial', JSON.stringify(model));
 
                     let importedTemplate = scInclude.querySelector_template_for_buggy_polyfill();
+
 
                     expect(importedTemplate.getAttribute("content")).to.equal('/sc/htmlmerger?scope1=scope1Html&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
                     expect(importedTemplate.model).to.equal(null);

--- a/test/partialAttribute/nested-html/given_in_JS.html
+++ b/test/partialAttribute/nested-html/given_in_JS.html
@@ -5,8 +5,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
-    <script src="../../../../web-component-tester/browser.js"></script>
     <script src="../../../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../../../document-register-element/build/document-register-element.js"></script>
+    <script src="../../../../web-component-tester/browser.js"></script>
 
     <!-- Step 1: import the element to test -->
     <link rel="import" href="../../../starcounter-include.html">

--- a/test/partialAttribute/nested-html/stamped_from_polymer_template.html
+++ b/test/partialAttribute/nested-html/stamped_from_polymer_template.html
@@ -11,6 +11,7 @@
     <!-- <script src="../../helpers/mock-htmlmerger.js"></script> -->
 
     <script src="../../../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../../../document-register-element/build/document-register-element.js"></script>
 
     <link rel="import" href="../../../../polymer/polymer.html">
     <!-- Step 1: import the element to test -->

--- a/test/partialAttribute/not_provided.html
+++ b/test/partialAttribute/not_provided.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
     <script src="../../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../../document-register-element/build/document-register-element.js"></script>
     <script src="../../../web-component-tester/browser.js"></script>
     <script src="../helpers/chainable-methods-for-partial.js"></script>
 
@@ -26,11 +27,28 @@
                 scInclude = document.createElement("starcounter-include");
             });
 
-            it('should have clear `imported-template`', function () {
+            it('should not have any children (CEv1 limitation)', function () {
+                expect(scInclude.children).to.be.empty;
+            });
+            it('once stamped imperatively by `.stampImportedTemplate()`, should have clear `imported-template`', function () {
+                scInclude.stampImportedTemplate();
                 expect(scInclude).to.have.descendant('[is="imported-template"]').that.is.a.clearImportedTemplate;
             });
+            describe('once connected to the DOM', function(){
+                beforeEach(function(done){
+                    document.body.appendChild(scInclude);
+                    // wait for connectedCallback polyfill
+                    setTimeout(done);
+                });
+                afterEach(function(){
+                    scInclude.parentNode.removeChild(scInclude);
+                });
+                it('once connected to DOM, should have clear `imported-template`', function () {
+                    expect(scInclude).to.have.descendant('[is="imported-template"]').that.is.a.clearImportedTemplate;
+                });
+            });
         });
-        describe('when created with no partial value', function () {
+        describe('when created in HTML with no partial value', function () {
             beforeEach(function () {
                 scInclude = fixture("starcounter-include");
             });

--- a/test/partialAttribute/not_stamped_from_polymer_template.html
+++ b/test/partialAttribute/not_stamped_from_polymer_template.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
     <script src="../../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../../document-register-element/build/document-register-element.js"></script>
     <script src="../../../web-component-tester/browser.js"></script>
     <script src="../helpers/chainable-methods-for-partial.js"></script>
 

--- a/test/partialAttribute/set_to_empty_object.html
+++ b/test/partialAttribute/set_to_empty_object.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
     <script src="../../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../../document-register-element/build/document-register-element.js"></script>
     <script src="../../../web-component-tester/browser.js"></script>
     <script src="../helpers/chainable-methods-for-partial.js"></script>
 

--- a/test/partialAttribute/stamped_from_polymer_template.html
+++ b/test/partialAttribute/stamped_from_polymer_template.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
     <script src="../../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../../document-register-element/build/document-register-element.js"></script>
     <script src="../../../web-component-tester/browser.js"></script>
 
     <link rel="import" href="../../../polymer/polymer.html">

--- a/test/partialId-property/reflect-partialId-to-attribute.html
+++ b/test/partialId-property/reflect-partialId-to-attribute.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 
     <script src="../../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../../document-register-element/build/document-register-element.js"></script>
     <script src="../../../web-component-tester/browser.js"></script>
     <script src="../helpers/chainable-methods-for-partial.js"></script>
 

--- a/test/template_w_declarative-shadow-dom.html
+++ b/test/template_w_declarative-shadow-dom.html
@@ -2,6 +2,6 @@
 	<h1 slot="my-slot">Template included</h1>
 	<template is="declarative-shadow-dom">
 		<h2>Custom Shadow DOM composition</h2>
-		<content select='[slot="my-slot"]'></content>
+		<slot name="my-slot"></slot>
 	</template>
 </template>

--- a/test/template_w_starcounter-composition.html
+++ b/test/template_w_starcounter-composition.html
@@ -2,6 +2,6 @@
 	<h1 slot="my-slot">Template included</h1>
 	<template is="starcounter-composition">
 		<h2>Custom Shadow DOM composition</h2>
-		<content select='[slot="my-slot"]'></content>
+		<slot name="my-slot"></slot>
 	</template>
 </template>

--- a/test/v0/basic.html
+++ b/test/v0/basic.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+    <title>starcounter-include basic test</title>
+    <script src="../../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../../document-register-element/build/document-register-element.js"></script>
+    <script src="../../../web-component-tester/browser.js"></script>
+    <script src="../helpers/pre-config.js"></script>
+    <link rel="import" href="../../../polymer/polymer.html">
+
+    <link rel="import" href="../../starcounter-include.html">
+</head>
+
+<body>
+    <template id="composition">
+        <h1>My shadow composition</h1>
+        with shadowElement
+        <content select='[slot="my-slot1"]'></content>
+        <!-- <slot name="my-slot1"></slot> -->
+        <content select='[slot="my-slot2"]'></content>
+    </template>
+    <test-fixture id="element">
+        <template>
+            <div>
+                <template is="dom-bind">
+                    <starcounter-include view-model="{{partial}}">
+                        <div id="childNode1" slot="my-slot1">childNode1</div>
+                        <div id="childNode2" slot="my-slot2">childNode2</div>
+                    </starcounter-include>
+                </template>
+            </div>
+        </template>
+    </test-fixture>
+</body>
+<script>
+    var scInclude, compositionTemplate, container, domBind, composition;
+    describe('starcounter-include', function () {
+
+
+        describe('when created', function () {
+            beforeEach(function () {
+                scInclude = document.createElement('starcounter-include');
+            });
+            it('should create shadowRoot', function () {
+                expect(scInclude).to.have.property('shadowRoot').to.be.not.null;
+                expect(scInclude).to.have.property('shadowRoot').instanceof(DocumentFragment);
+            });
+            it('should create shadowRoot with default slot', function () {
+                expect(scInclude.shadowRoot.querySelector('content')).to.be.not.null;
+                expect(scInclude.shadowRoot.querySelector('content')).to.be.instanceof(HTMLContentElement);
+            });
+        });
+
+        describe('when `.composition` property is set, once `.stamp` method is called', function () {
+            beforeEach(function (done) {
+                container = fixture('element');
+                domBind = container.querySelector('template[is="dom-bind"]');
+                // domBind.addEventListener('dom-change', function waitForDomBind(){
+                    scInclude = container.querySelector('starcounter-include');
+                    composition = document.querySelector('#composition').innerHTML;
+                    domBind.set('partial', {CompositionProvider:{Composition$: null}});
+                    domBind.set('partial.CompositionProvider.Composition$', composition);
+                    // setTimeout(function waitForPolyfilledUpgrade(){
+                        done();
+                    // },100);
+
+                // });
+            });
+            it('should create shadowRoot with given Document Fragment', function () {
+                expect(scInclude).to.have.property('shadowRoot');
+                // expect(scInclude.shadowRoot).to.have.property('innerHTML', compositionTemplate.innerHTML);
+                expect(scInclude.shadowRoot.innerHTML).to.equal(composition);
+            });
+            it('should distribute its children, which has `slot` attribute matching slot(content) tag within given shadow DOM', function () {
+                expect(scInclude.children[1].getDestinationInsertionPoints().length).to.be.greaterThan(0);
+            });
+        });
+    });
+</script>
+
+</html>

--- a/test/v0/smoke/webcomponents-webcomponentsjs-issues-648.html
+++ b/test/v0/smoke/webcomponents-webcomponentsjs-issues-648.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+    <title>starcounter-include basic test</title>
+    <script src="../../../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../../../document-register-element/build/document-register-element.js"></script>
+    <script src="../../../../web-component-tester/browser.js"></script>
+    <script src="../../helpers/pre-config.js"></script>
+
+    <link rel="import" href="../../../starcounter-include.html">
+</head>
+
+<body>
+    <template id="composition"><div style="background: green;"><content select="[slot='something']"></content><content select="[slot='else']"></content></div></template>
+    <test-fixture id="element">
+        <template>
+            <starcounter-include>
+        </starcounter-include>
+        </template>
+    </test-fixture>
+</body>
+<script>
+    var scInclude, compositionTemplate;
+    describe('starcounter-include', function () {
+
+
+        describe('when `.composition` property is set, then `.stamp` method is called, an element is added, another element is added asynchronously', function () {
+            beforeEach(function (done) {
+                scInclude = fixture('element');
+                compositionTemplate = document.querySelector('#composition');
+    			scInclude.viewModel = {
+    				CompositionProvider:{
+    					Composition$: compositionTemplate.innerHTML
+    				}
+    			};
+                // scInclude.stamp();
+                const div = document.createElement('div');
+                div.setAttribute('slot', 'something');
+                div.innerHTML = 'Am I green?';
+                scInclude.appendChild(div);
+
+                setTimeout(function(){
+
+                    const div = document.createElement('div');
+                    div.setAttribute('slot', 'else');
+                    div.innerHTML = 'Am I green?';
+                    scInclude.appendChild(div);
+                    // expect(scInclude.shadowRoot.innerHTML).to.equal(compositionTemplate.innerHTML);
+                    setTimeout(function(){
+                        done();
+                    });
+                });
+            });
+            it('eventually it should have shadowRoot with given Document Fragment', function () {
+                expect(scInclude.shadowRoot.innerHTML).to.equal(compositionTemplate.innerHTML);
+            });
+        });
+    });
+</script>
+
+</html>

--- a/test/v0/translate/v1-to-v0.html
+++ b/test/v0/translate/v1-to-v0.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html>
+
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+
+	<script src="../../../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../../../document-register-element/build/document-register-element.js"></script>
+	<script src="../../../../web-component-tester/browser.js"></script>
+	<script src="../../helpers/pre-config.js"></script>
+
+	<link rel="import" href="../../../starcounter-include.html">
+</head>
+
+<body>
+	<test-fixture id="element">
+		<template>
+			<starcounter-include></starcounter-include>
+		</template>
+	</test-fixture>
+	<template id="reference-composition">
+		<style>
+			.foo,
+			::content>p,
+			.bar{
+				color: green;
+			}
+		</style>
+		<h2>Custom Shadow DOM composition</h2>
+		<content name="my-slot" select="[slot='my-slot']"></content>
+		<content name='my-slot' select="[slot='my-slot']"></content>
+		<content></content>
+		<content name="my-slot" select="[slot='my-slot']"></content>
+		<content></content>
+		<content foo="bar" name="my-slot" baz select="[slot='my-slot']"></content>
+		<content select="[slot='untouched']"></content>
+	</template>
+
+	<template id="composition">
+		<style>
+			.foo,
+			::slotted(p),
+			.bar{
+				color: green;
+			}
+		</style>
+		<h2>Custom Shadow DOM composition</h2>
+		<slot name="my-slot"></slot>
+		<slot name='my-slot'></slot>
+		<slot></slot>
+		<slot    name="my-slot"    ></slot>
+		<slot       ></slot   >
+		<slot foo="bar" name="my-slot" baz></slot>
+		<content select="[slot='untouched']"></content>
+	</template>
+
+
+	<script>
+	describe('starcounter-include when stamps a composition which contains V1 `slot`s and `::slotted`', function () {
+
+		var scInclude;
+		afterEach(function (done) {
+			// give more time to polyfill cleanup
+			setTimeout(done);
+		});
+		beforeEach(function (done) {
+			scInclude = fixture('element');
+			scInclude.viewModel = {
+				CompositionProvider:{
+					Composition$: document.querySelector('#composition').innerHTML
+				}
+			};
+			// scInclude.stamp();
+			setTimeout(done, 500);
+			// done();
+		});
+		it('should replace them with applicable content', function () {
+			expect(scInclude.shadowRoot).to.be.not.null;
+			expect(scInclude.shadowRoot.innerHTML.trim()).to.be
+				.equal(document.querySelector('#reference-composition').innerHTML.trim());
+		});
+		describe('after composition property is replaced with the new composition that also contains slots and `::slotted`', function () {
+			beforeEach(function (done) {
+				scInclude.composition = document.importNode(document.querySelector('#composition').content, true);
+				setTimeout(done, 500);
+			});
+			it('should replace them with applicable content', function () {
+				expect(scInclude.shadowRoot).to.be.not.null;
+				expect(scInclude.shadowRoot.innerHTML.trim()).to.be
+					.equal(document.querySelector('#reference-composition').innerHTML.trim());
+			});
+		});
+
+	});
+	</script>
+
+</body>
+
+</html>

--- a/test/v1/basic.html
+++ b/test/v1/basic.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+    <title>starcounter-include composition basic test</title>
+    <script src="../../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../../web-component-tester/browser.js"></script>
+    <script src="../helpers/pre-config.js"></script>
+    <link rel="import" href="../../../polymer/polymer.html">
+
+    <link rel="import" href="../../starcounter-include.html">
+</head>
+
+<body>
+    <template id="composition">
+        <h1>My shadow composition</h1>
+        with shadowElement
+        <slot name="my-slot1"></slot>
+        <slot name="my-slot2"></slot>
+    </template>
+    <test-fixture id="element">
+        <template>
+            <div>
+                <template is="dom-bind">
+                    <starcounter-include view-model="{{partial}}">
+                        <div id="childNode1" slot="my-slot1">childNode1</div>
+                        <div id="childNode2" slot="my-slot2">childNode2</div>
+                    </starcounter-include>
+                </template>
+            </div>
+        </template>
+    </test-fixture>
+</body>
+<script>
+    var scInclude, compositionTemplate, container, domBind, composition;
+    describe('starcounter-include', function () {
+
+
+        describe('when created', function () {
+            beforeEach(function () {
+                scInclude = document.createElement('starcounter-include');
+            });
+            it('should create shadowRoot', function () {
+                expect(scInclude).to.have.property('shadowRoot').to.be.not.null;
+                expect(scInclude).to.have.property('shadowRoot').instanceof(DocumentFragment);
+            });
+            it('should create shadowRoot with default slot', function () {
+                expect(scInclude.shadowRoot.querySelector('slot')).to.be.not.null;
+                expect(scInclude.shadowRoot.querySelector('slot')).to.be.instanceof(HTMLSlotElement);
+            });
+        });
+
+        describe('when `.CompositionProvider.Composition$` property is set', function () {
+            beforeEach(function (done) {
+                container = fixture('element');
+                domBind = container.querySelector('template[is="dom-bind"]');
+                // domBind.addEventListener('dom-change', function waitForDomBind(){
+                    scInclude = container.querySelector('starcounter-include');
+                    composition = document.querySelector('#composition').innerHTML;
+                    domBind.set('partial', {CompositionProvider:{Composition$: null}});
+                    domBind.set('partial.CompositionProvider.Composition$', composition);
+                    // setTimeout(function waitForPolyfilledUpgrade(){
+                        done();
+                    // },100);
+
+                // });
+            });
+            it('should create shadowRoot with given Document Fragment', function () {
+                expect(scInclude).to.have.property('shadowRoot');
+                // expect(scInclude.shadowRoot).to.have.property('innerHTML', compositionTemplate.innerHTML);
+                expect(scInclude.shadowRoot.innerHTML).to.equal(composition);
+            });
+            it('should distribute its children, which has `slot` attribute matching slot(content) tag within given shadow DOM', function () {
+                expect(scInclude.children[1].assignedSlot).to.be.not.null;
+            });
+        });
+    });
+</script>
+
+</html>

--- a/test/v1/smoke/webcomponents-webcomponentsjs-issues-648.html
+++ b/test/v1/smoke/webcomponents-webcomponentsjs-issues-648.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+    <title>starcounter-include basic test</title>
+    <script src="../../../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../../../web-component-tester/browser.js"></script>
+    <script src="../../helpers/pre-config.js"></script>
+
+    <link rel="import" href="../../../starcounter-include.html">
+</head>
+
+<body>
+    <template id="composition"><div style="background: green;"><slot name="something"></slot><slot name="else"></slot></div></template>
+    <test-fixture id="element">
+        <template>
+            <starcounter-include>
+            </starcounter-include>
+        </template>
+    </test-fixture>
+</body>
+<script>
+    var scInclude, compositionTemplate;
+    describe('starcounter-include', function () {
+
+
+        describe('when `.composition` property is set, then `.stamp` method is called, an element is added, another element is added asynchronously', function () {
+            beforeEach(function (done) {
+                scInclude = fixture('element');
+                compositionTemplate = document.querySelector('#composition');
+    			scInclude.viewModel = {
+    				CompositionProvider:{
+    					Composition$: compositionTemplate.innerHTML
+    				}
+    			};
+                // scInclude.stamp();
+                const div = document.createElement('div');
+                div.setAttribute('slot', 'something');
+                div.innerHTML = 'Am I green?';
+                scInclude.appendChild(div);
+
+                setTimeout(function(){
+
+                    const div = document.createElement('div');
+                    div.setAttribute('slot', 'else');
+                    div.innerHTML = 'Am I green?';
+                    scInclude.appendChild(div);
+                    // expect(scInclude.shadowRoot.innerHTML).to.equal(compositionTemplate.innerHTML);
+                    setTimeout(function(){
+                        done();
+                    });
+                });
+            });
+            it('eventually it should have shadowRoot with given Document Fragment', function () {
+                expect(scInclude.shadowRoot.innerHTML).to.equal(compositionTemplate.innerHTML);
+            });
+        });
+    });
+</script>
+
+</html>

--- a/test/v1/translate/v0-to-v1.html
+++ b/test/v1/translate/v0-to-v1.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html>
+
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+
+	<script src="../../../../webcomponentsjs/webcomponents.js"></script>
+	<script src="../../../../web-component-tester/browser.js"></script>
+	<script src="../../helpers/pre-config.js"></script>
+
+	<link rel="import" href="../../../starcounter-include.html">
+</head>
+
+<body>
+	<test-fixture id="element">
+		<template>
+			<starcounter-include></starcounter-include>
+		</template>
+	</test-fixture>
+	<template id="composition">
+		<style>
+			.foo,
+			::content p,
+			.bar{
+				color: green;
+			}
+		</style>
+		<h2>Custom Shadow DOM composition</h2>
+		<content select="[slot='my-slot']"></content>
+		<content></content>
+		<content    select="[slot='my-slot']"    ></content>
+		<content    ></content    >
+		<content foo="bar" select="[slot='my-slot']" baz></content>
+		<content name="old-name" select="[slot='my-slot']"></content>
+		<content select="[name='my-slot']"></content>
+		<content select=".other-selector"></content>
+		<slot name="untouched"></slot>
+	</template>
+
+	<template id="reference-composition">
+		<style>
+			.foo,
+			::slotted(p)/* FIXME V1 matches only direct children;*/,
+			.bar{
+				color: green;
+			}
+		</style>
+		<h2>Custom Shadow DOM composition</h2>
+		<slot select="[slot='my-slot']" name="my-slot"></slot>
+		<slot></slot>
+		<slot    select="[slot='my-slot']"     name="my-slot"></slot>
+		<slot    ></slot    >
+		<slot foo="bar" select="[slot='my-slot']" baz name="my-slot"></slot>
+		<slot select="[slot='my-slot']" name="my-slot"></slot>
+		<slot select="[name='my-slot']"></slot>
+		<slot select=".other-selector"></slot>
+		<slot name="untouched"></slot>
+	</template>
+
+
+	<script>
+	describe('starcounter-include when stamps a composition which contains V0 `content` tags and `::content`', function () {
+
+		var scInclude;
+		afterEach(function (done) {
+			// give more time to polyfill cleanup
+			setTimeout(done);
+		});
+		beforeEach(function (done) {
+			scInclude = fixture('element');
+			scInclude.viewModel = {
+				CompositionProvider:{
+					Composition$: document.querySelector('#composition').innerHTML
+				}
+			};
+			// scInclude.stamp();
+			// setTimeout(done, 500);
+			done();
+		});
+		it('should replace them with applicable `slot`s and `::slotted`', function () {
+			expect(scInclude.shadowRoot).to.be.not.null;
+			expect(scInclude.shadowRoot.innerHTML.trim()).to.be
+				.equal(document.querySelector('#reference-composition').innerHTML.trim());
+		});
+		describe('after composition property is replaced with the new composition that also contains `content` tags and `::content`', function () {
+			beforeEach(function (done) {
+				scInclude.composition = document.importNode(document.querySelector('#composition').content, true);
+				setTimeout(done, 500);
+			});
+			it('should replace them with applicable content', function () {
+				expect(scInclude.shadowRoot).to.be.not.null;
+				expect(scInclude.shadowRoot.innerHTML.trim()).to.be
+					.equal(document.querySelector('#reference-composition').innerHTML.trim());
+			});
+		});
+
+	});
+	</script>
+
+</body>
+
+</html>


### PR DESCRIPTION
Migrate to CE v1, Remove juicy-composition wrapper from light DOM

https://github.com/Starcounter/starcounter-include/issues/39
https://github.com/Starcounter/starcounter-include/issues/42
Drop feature to automatically create slot elements and slot attributes.
https://github.com/Starcounter/RebelsLounge/issues/107

https://github.com/Starcounter/starcounter-include/issues/32
Add default slot if there is no composition, for specific ones it should come from server (merged html)
https://github.com/Juicy/juicy-composition/issues/4

related
https://github.com/Starcounter/RebelsLounge/issues/106
https://github.com/Starcounter/starcounter-include/issues/26
https://github.com/Starcounter/RebelsLounge/issues/78

-----
:warning: this is a breaking change!: selectors like `starcounter-include>juicy-composition>*` needs to be updated to `starcounter-include>*`
> I'd put it on SysUpgrade to test carefully.

This is needed to make migration to V1 easier.