### PR TITLE
Apply polyfill `.shimStyling` to support Shadow DOM selectors in V0

### DIFF
--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -418,6 +418,8 @@ version: 3.0.0-rc.1
                 }
 
                 shadowRoot.appendChild(givenComposition);
+                // polyfill `polyfill-next-selector` if needed
+                WebComponents && WebComponents.ShadowCSS && WebComponents.ShadowCSS.shimStyling(shadowRoot);
                 this.isStamped = true;
             } else if(shadowRoot){
                 shadowRoot.innerHTML = defaultShadowCSS + defaultShadowDOM;

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -419,7 +419,11 @@ version: 3.0.0-rc.1
 
                 shadowRoot.appendChild(givenComposition);
                 // polyfill `polyfill-next-selector` if needed
-                WebComponents && WebComponents.ShadowCSS && WebComponents.ShadowCSS.shimStyling(shadowRoot);
+                WebComponents && WebComponents.ShadowCSS &&
+                    WebComponents.ShadowCSS.replaceTextInStyles(
+                        WebComponents.ShadowCSS.findStyles(shadowRoot),
+                        WebComponents.ShadowCSS.insertDirectives
+                    );
                 this.isStamped = true;
             } else if(shadowRoot){
                 shadowRoot.innerHTML = defaultShadowCSS + defaultShadowDOM;

--- a/test/index.html
+++ b/test/index.html
@@ -38,7 +38,8 @@
         var v0suites = [
             'v0/basic.html',
             'v0/translate/v1-to-v0.html', // translate between v0 and v1
-            'v0/smoke/webcomponents-webcomponentsjs-issues-648.html' // add missing slots
+            'v0/smoke/webcomponents-webcomponentsjs-issues-648.html', // add missing slots
+            'v0/polyfill-next-selector.html' // use polyfill for styles
         ];
         var v1suites = [
             'v1/basic.html',

--- a/test/v0/polyfill-next-selector.html
+++ b/test/v0/polyfill-next-selector.html
@@ -51,14 +51,14 @@
 <script>
 describe('starcounter-include when stamps a composition which contains `polyfill-next-selector`', function () {
 
-	var scInclude, shimStyling;
+	var scInclude, replaceTextInStyles;
 	afterEach(function (done) {
 		// give more time to polyfill cleanup
 		setTimeout(done);
 	});
 	beforeEach(function (done) {
         if(WebComponents && WebComponents.ShadowCSS){
-            shimStyling = sinon.spy(WebComponents.ShadowCSS, 'shimStyling');
+            replaceTextInStyles = sinon.spy(WebComponents.ShadowCSS, 'replaceTextInStyles');
         }
 		scInclude = fixture('element');
 		scInclude.viewModel = {
@@ -71,11 +71,14 @@ describe('starcounter-include when stamps a composition which contains `polyfill
 		// done();
 	});
     afterEach(function(){
-        shimStyling.restore();
+        replaceTextInStyles.restore();
     });
-	it('should call `WebComponents.ShadowCSS.shimStyling(shadowRoot);` on it\'s shadowRoot', function () {
-		expect(shimStyling).to.have.been.called;
-		expect(shimStyling).to.be.calledWith(scInclude.shadowRoot);
+	it('should call `WebComponents.ShadowCSS.replaceTextInStyles(styles, insertDirectives);` on it\'s shadowRoot', function () {
+		expect(replaceTextInStyles).to.have.been.called;
+		expect(replaceTextInStyles).to.be.calledWith(
+            WebComponents.ShadowCSS.findStyles(scInclude.shadowRoot),
+            WebComponents.ShadowCSS.insertDirectives
+        );
 	});
 	it('should replace polyfilled selector', function () {
 		expect(scInclude.shadowRoot).to.be.not.null;

--- a/test/v0/polyfill-next-selector.html
+++ b/test/v0/polyfill-next-selector.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+    <title>starcounter-include basic test</title>
+    <script src="../../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../../document-register-element/build/document-register-element.js"></script>
+    <script src="../../../web-component-tester/browser.js"></script>
+    <script src="../helpers/pre-config.js"></script>
+    <link rel="import" href="../../../polymer/polymer.html">
+
+    <link rel="import" href="../../starcounter-include.html">
+</head>
+
+<body>
+    <template id="composition">
+        <style>
+            polyfill-next-selector { content: '.my-class > *'; }
+            .my-class ::content {
+                font-size: 20px;
+            }
+        </style>
+        <h1>My shadow composition</h1>
+        with shadowElement
+        <div class="my-class"><content select='[slot="my-slot1"]'></content></div>
+        <content select='[slot="my-slot2"]'></content>
+    </template>
+	<template id="reference-composition">
+        <style>
+            .my-class > * {
+                font-size: 20px;
+            }
+        </style>
+        <h1>My shadow composition</h1>
+        with shadowElement
+        <div class="my-class"><content select='[slot="my-slot1"]'></content></div>
+        <content select='[slot="my-slot2"]'></content>
+	</template>
+    <test-fixture id="element">
+		<template>
+            <starcounter-include>
+                <div id="childNode1" slot="my-slot1">childNode1</div>
+                <div id="childNode2" slot="my-slot2">childNode2</div>
+            </starcounter-include>
+        </template>
+    </test-fixture>
+</body>
+
+<script>
+describe('starcounter-include when stamps a composition which contains `polyfill-next-selector`', function () {
+
+	var scInclude, shimStyling;
+	afterEach(function (done) {
+		// give more time to polyfill cleanup
+		setTimeout(done);
+	});
+	beforeEach(function (done) {
+        if(WebComponents && WebComponents.ShadowCSS){
+            shimStyling = sinon.spy(WebComponents.ShadowCSS, 'shimStyling');
+        }
+		scInclude = fixture('element');
+		scInclude.viewModel = {
+			CompositionProvider:{
+				Composition$: document.querySelector('#composition').innerHTML
+			}
+		};
+		// scInclude.stamp();
+		setTimeout(done, 500);
+		// done();
+	});
+    afterEach(function(){
+        shimStyling.restore();
+    });
+	it('should call `WebComponents.ShadowCSS.shimStyling(shadowRoot);` on it\'s shadowRoot', function () {
+		expect(shimStyling).to.have.been.called;
+		expect(shimStyling).to.be.calledWith(scInclude.shadowRoot);
+	});
+	it('should replace polyfilled selector', function () {
+		expect(scInclude.shadowRoot).to.be.not.null;
+		expect(scInclude.shadowRoot.innerHTML.trim()).to.be
+			.equal(document.querySelector('#reference-composition').innerHTML.trim());
+	});
+	it('should apply rules correctly', function () {
+		expect(getComputedStyle(scInclude.children[0])['font-size']).to.be.equal('20px')
+	});
+
+});
+</script>
+
+</html>


### PR DESCRIPTION
add suport for `polyfill-next-selector`, as in
https://github.com/webcomponents/webcomponentsjs/blob/v0/README.md#shadowcss-host-contexthost-doesnt-work-

Fixes problem discovered at
https://github.com/StarcounterApps/Website/pull/172#issuecomment-321535201

-----

Previously (as you can see in tests)
`.my-class ::content` selectors were not working  at all. Now, we can polyfill them with `polyfill-next-selector { content: '.my-class > *'; }`

Please not, that `.my-class ::content, .my-class > *` is not a good workaround, as it does not work in Firefox, and may result in side effects in browsers that supports Shadow DOM natively.