### PR TITLE
Improvements after PR #60

### DIFF
--- a/sc/template_w_declarative-shadow-dom-alternative.html
+++ b/sc/template_w_declarative-shadow-dom-alternative.html
@@ -1,7 +1,7 @@
 <template>
-    <h1 slot="my-slot">Template included</h1>
+    <h1 slot="my-slot">Alternative template included</h1>
     <template is="declarative-shadow-dom">
-        <h2>Custom Shadow DOM composition</h2>
+        <h2>Custom Shadow DOM alternative composition</h2>
         <slot name="my-slot"></slot>
     </template>
 </template>

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -210,35 +210,59 @@ version: 3.0.0-rc.6
                 this.template.model = this.partial
             }
         };
+
+        /**
+         * Stamps composition if needed
+         * @param  {String} compositionString HTML as a string to compare if a re-render is needed
+         * @param  {Function} callb Function that returns a composition to render
+         */
+        StarcounterIncludePrototype._renderCompositionChange = function(compositionString, callb) {
+            if (!this._forceLayoutChange && this._lastCompositionString == compositionString) {
+                return;
+            }
+            let composition = callb();
+            this.stampComposition(composition);
+            this._forceLayoutChange = false;
+            this._lastCompositionString = compositionString;
+        }
+
         /**
          * Handles change of the composition.
          * If not given explicitely, fetches one from provider.
-         * Stamps if needed.
+         * If not given in provider, fetches one from imported template's default composition.
+         * If imported template does not have a default composition, uses fallback composition.
+         * Warning: the explicit composition might come from https://github.com/Starcounter/starcounter-layout-html-editor/blob/17b21f729facd9a8dcd4241fb5c48cb71de11af5/starcounter-layout-html-editor.html#L253
          * @see .stampComposition
          * @param  {String} compositionString stringified HTML for new Shadow Root
          */
         StarcounterIncludePrototype._compositionChanged = function(compositionString) {
-            let composition;
-            if (this.partial && compositionString === undefined) {
-                const compositionProvider = findCompositionProvider(this.partial);
-                if (compositionProvider) {
-                    compositionString = compositionProvider.Composition$; //should always be string
-                    this.storedLayout = compositionString;
+            var that = this;
+
+            if (compositionString !== undefined) {
+                this._forceLayoutChange = true;
+                this._renderCompositionChange("explicit or fallback", function() {
+                    return that.stringToDocumentFragment(compositionString);
+                });
+            }
+            else {
+                const compositionProvider = this.partial && findCompositionProvider(this.partial);
+                if (compositionProvider && compositionProvider.Composition$) {
+                    this._renderCompositionChange(compositionProvider.Composition$, function() {
+                        that.storedLayout = compositionProvider.Composition$; //should always be string
+                        return that.stringToDocumentFragment(that.storedLayout);
+                    });
                 }
-            }
-            // do not change if there is one, it's same as before, and we are not forced
-            if (!compositionString) {
-                composition = this.defaultComposition && this.defaultComposition.cloneNode(true);
-                compositionString = this.defaultComposition;
-            } else {
-                // make clone to avoid direct binding
-                composition = this.stringToDocumentFragment(compositionString);
-            }
-            if (!compositionString || compositionString !== this._lastLayout || this._forceLayoutChange) {
-                this.stampComposition(composition);
-                this._forceLayoutChange = false;
-                this._lastLayout = compositionString;
-            }
+                else if (this.defaultComposition) {
+                    this._renderCompositionChange("imported template's default", function() {
+                        return that.defaultComposition.cloneNode(true);
+                    });
+                }
+                else {
+                    this._renderCompositionChange("explicit or fallback", function() {
+                        return undefined;
+                    });
+                }
+            }            
         };
         /**
          * Forward Polymer notification downwards from `<template is="dom-bind">`

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -271,7 +271,7 @@ version: 3.0.0-rc.6
          * @param  {Mixed} value New value
          */
         StarcounterIncludePrototype._notifyPath = function(path, value) {
-            var modelAlreadyLoaded = this.template.model == this.partial;
+            var sameModelAlreadyLoaded = this.template.model == this.partial;
             if (path.indexOf("partial.") === 0 || path.indexOf("viewModel.") === 0) {
                 if (
                     // path === "viewModel.Html" || // covered by  viewModel._whatever_
@@ -304,7 +304,7 @@ version: 3.0.0-rc.6
                     } else {
                         this.partialChanged(this.partial);
 
-                        if (modelAlreadyLoaded && this.template._notifyPath) {
+                        if (sameModelAlreadyLoaded && this.template._notifyPath) {
                             this.template._notifyPath(
                                 path.replace("partial.", "model.")
                                     .replace("viewModel.", "model."),

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -334,30 +334,11 @@ version: 3.0.0-rc.6
         StarcounterIncludePrototype.saveLayout = function(compositionStr){
             compositionStr = compositionStr || this.shadowRoot.innerHTML;
             this.storedLayout = compositionStr;
-            //TODO: trigger polymer-protocol-compliant event
-
-            // FIXME: temporary workaround for servers not accepting JSON-Patch
-            // from juicy-tiles-setup-sync
-            var req = new XMLHttpRequest();
-            req.open("POST", this.compositionAPI + "?key=" + encodeURIComponent(this.partialId) + '&ver=', true);
-            req.onreadystatechange = function () {
-                if (req.readyState == 4) {
-                    if (!(req.status >= 200 && req.status <= 299)) {
-                        console.error("Failed to save composition configuration");
-                        return;
-                    }
-                    console.info("composition configuration saved");
-                }
-                // FIXME: bellow is required for save button not to overwrite with old value, but it fails due to puppet error
-                console.info('Direct change to model is required for save button not to overwrite with old value, but it fails due to puppet error.');
-                findCompositionProvider(this.partial).Composition$ = this.storedLayout;
-                this.dispatchEvent(new CustomEvent("starcounter-include-composition-saved", {detail: this.storedLayout}));
-                // trigger polymer-notification-protocol-compilant event
-                this.dispatchEvent(new CustomEvent("partial-changed", {detail: {value: this.storedLayout, path: 'partial.' + findCompositionProviderPath(this.partial) + '.Composition$'}}));
-                this.dispatchEvent(new CustomEvent("view-model-changed", {detail: {value: this.storedLayout, path: 'viewModel.' + findCompositionProviderPath(this.partial) + '.Composition$'}}));
-            }.bind(this);
-            return req.send(this.storedLayout);
-
+            findCompositionProvider(this.partial).Composition$ = this.storedLayout;
+            this.dispatchEvent(new CustomEvent("starcounter-include-composition-saved", {detail: this.storedLayout}));
+            // trigger polymer-notification-protocol-compilant event
+            this.dispatchEvent(new CustomEvent("partial-changed", {detail: {value: this.storedLayout, path: 'partial.' + findCompositionProviderPath(this.partial) + '.Composition$'}}));
+            this.dispatchEvent(new CustomEvent("view-model-changed", {detail: {value: this.storedLayout, path: 'viewModel.' + findCompositionProviderPath(this.partial) + '.Composition$'}}));
         };
 
         // stringToDocumentFragment(strHTML) from http://stackoverflow.com/a/25214113/868184

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -182,8 +182,6 @@ version: 3.0.0-rc.6
          */
         StarcounterIncludePrototype.partialChanged = function(newVal) {
             this._htmlChanged();
-            const compositionProvider = this.partial && findCompositionProvider(this.partial);
-            this.partialId = compositionProvider && compositionProvider.PartialId; //should always be string
             this._compositionChanged();
         };
         StarcounterIncludePrototype._htmlChanged = function() {
@@ -246,6 +244,8 @@ version: 3.0.0-rc.6
             }
             else {
                 const compositionProvider = this.partial && findCompositionProvider(this.partial);
+                this.partialId = compositionProvider && compositionProvider.PartialId;
+
                 if (compositionProvider && compositionProvider.Composition$) {
                     this._renderCompositionChange(compositionProvider.Composition$, function() {
                         that.storedLayout = compositionProvider.Composition$; //should always be string
@@ -272,46 +272,12 @@ version: 3.0.0-rc.6
          */
         StarcounterIncludePrototype._notifyPath = function(path, value) {
             var sameModelAlreadyLoaded = this.template.model == this.partial;
-            if (path.indexOf("partial.") === 0 || path.indexOf("viewModel.") === 0) {
-                if (
-                    // path === "viewModel.Html" || // covered by  viewModel._whatever_
-                    // path.match(/^viewModel\.[^.]+\.Html$/)
-                    (path.indexOf('.Html') === path.length - 5) && path.slice(10, -5).indexOf('.') === -1
-                ) {
-                    this.partialChanged(this.partial);
-                } else if (
-                    // path === "partial.Html" || // covered by  partial._whatever_
-                    // path.match(/^partial\.[^.]+\.Html$/)
-                    (path.indexOf('.Html') === path.length - 5) && path.slice(8, -5).indexOf('.') === -1
-                ) {
-                    this.partialChanged(this.partial);
-                } else {
-                    const compositionProviderPath = findCompositionProviderPath(this.partial);
-                    // if (path === 'partial.' + compositionProviderPath ||
-                    //     path === 'viewModel.' + compositionProviderPath) {
-                    //     // .Composition$ and .PartialId may have changed, also CompositionProvider theoretically could provide it's .Html as well
-                    //     this.partialChanged();
-                    // } else
-                    if(
-                        // .Composition$ have changed
-                        path === 'partial.' + compositionProviderPath  + '.Composition$'||
-                        path === 'viewModel.' + compositionProviderPath + '.Composition$'
-                    ) {
-                        this._compositionChanged();
-                    } else if (path === 'partial.' + compositionProviderPath + '.PartialId' || path === 'viewModel.' + compositionProviderPath + '.PartialId') {
-                        const compositionProvider = findCompositionProvider(this.partial);
-                        this.partialId = compositionProvider && compositionProvider.PartialId; //should always be string
-                    } else {
-                        this.partialChanged(this.partial);
-
-                        if (sameModelAlreadyLoaded && this.template._notifyPath) {
-                            this.template._notifyPath(
-                                path.replace("partial.", "model.")
-                                    .replace("viewModel.", "model."),
-                                 value);
-                        }
-                    }
-                }
+            this.partialChanged(this.partial);
+            if (sameModelAlreadyLoaded && this.template._notifyPath) {
+                this.template._notifyPath(
+                    path.replace("partial.", "model.")
+                        .replace("viewModel.", "model."),
+                     value);
             }
         };
         /**

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -215,14 +215,13 @@ version: 3.0.0-rc.6
          * @param  {Function} callb Function that returns a composition to render
          */
         StarcounterIncludePrototype._renderCompositionChange = function(compositionRef, callb) {
-            if (!this._forceLayoutChange && this._lastCompositionRef == compositionRef) {
-                return;
+            if (this._forceLayoutChange || this._lastCompositionRef !== compositionRef) {
+                this.storedLayout = null;
+                let composition = callb();
+                this.stampComposition(composition);
+                this._forceLayoutChange = false;
+                this._lastCompositionRef = compositionRef;
             }
-            this.storedLayout = null;
-            let composition = callb();
-            this.stampComposition(composition);
-            this._forceLayoutChange = false;
-            this._lastCompositionRef = compositionRef;
         }
 
         /**
@@ -235,39 +234,41 @@ version: 3.0.0-rc.6
          * @param  {String} compositionString stringified HTML for new Shadow Root
          */
         StarcounterIncludePrototype._compositionChanged = function(compositionString) {
-            var that = this;
-
             if (compositionString) {
                 this._forceLayoutChange = true;
-                this._renderCompositionChange("explicit or fallback", function() {
-                    return that.stringToDocumentFragment(compositionString);
+                this._renderCompositionChange("explicit or fallback", () => {
+                    return this.stringToDocumentFragment(compositionString);
                 });
             }
             else {
                 const compositionProvider = this.partial && findCompositionProvider(this.partial);
-                this.partialId = compositionProvider && compositionProvider.PartialId;
 
-                if (compositionProvider && compositionProvider.Composition$ && compositionString === "") {
-                    //this is a request from starcounter-layout-html-editor to reset to default composition
-                    that.Composition$ = "";
-                }
-
-                if (compositionProvider && compositionProvider.Composition$) {
-                    this._renderCompositionChange(compositionProvider.Composition$, function() {
-                        that.storedLayout = compositionProvider.Composition$; //should always be string
-                        return that.stringToDocumentFragment(that.storedLayout);
-                    });
-                }
-                else if (this.defaultComposition) {
-                    this._renderCompositionChange(this.defaultComposition, function() {
-                        return that.defaultComposition.cloneNode(true);
-                    });
+                if (compositionProvider) {
+                    this.partialId = compositionProvider.PartialId;
+                    if (compositionString === "") {
+                        //this is a request from starcounter-layout-html-editor to reset to default composition
+                        this.Composition$ = "";
+                    }
+                    else if (compositionProvider.Composition$) {
+                        return this._renderCompositionChange(compositionProvider.Composition$, () => {
+                            this.storedLayout = compositionProvider.Composition$; //should always be string
+                            return this.stringToDocumentFragment(this.storedLayout);
+                        });
+                    }
                 }
                 else {
-                    this._renderCompositionChange("explicit or fallback", function() {
-                        return undefined;
+                    this.partialId = null;
+                }
+
+                if (this.defaultComposition) {
+                    return this._renderCompositionChange(this.defaultComposition, () => {
+                        return this.defaultComposition.cloneNode(true);
                     });
                 }
+                
+                return this._renderCompositionChange("explicit or fallback", () => {
+                    return undefined;
+                });
             }            
         };
         /**
@@ -337,8 +338,9 @@ version: 3.0.0-rc.6
             findCompositionProvider(this.partial).Composition$ = this.storedLayout;
             this.dispatchEvent(new CustomEvent("starcounter-include-composition-saved", {detail: this.storedLayout}));
             // trigger polymer-notification-protocol-compilant event
-            this.dispatchEvent(new CustomEvent("partial-changed", {detail: {value: this.storedLayout, path: 'partial.' + findCompositionProviderPath(this.partial) + '.Composition$'}}));
-            this.dispatchEvent(new CustomEvent("view-model-changed", {detail: {value: this.storedLayout, path: 'viewModel.' + findCompositionProviderPath(this.partial) + '.Composition$'}}));
+            var notificationPath = findCompositionProviderPath(this.partial) + '.Composition$';
+            this.dispatchEvent(new CustomEvent("partial-changed", {detail: {value: this.storedLayout, path: 'partial.' + notificationPath}}));
+            this.dispatchEvent(new CustomEvent("view-model-changed", {detail: {value: this.storedLayout, path: 'viewModel.' + notificationPath}}));
         };
 
         // stringToDocumentFragment(strHTML) from http://stackoverflow.com/a/25214113/868184

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -234,9 +234,7 @@ version: 3.0.0-rc.6
         StarcounterIncludePrototype._compositionChanged = function(compositionString) {
             if (compositionString) {
                 this._forceLayoutChange = true;
-                this._renderCompositionChange("explicit or fallback", () => {
-                    return this.stringToDocumentFragment(compositionString);
-                });
+                this._renderCompositionChange("explicit or fallback", () => this.stringToDocumentFragment(compositionString));
             }
             else {
                 const compositionProvider = this.partial && findCompositionProvider(this.partial);
@@ -259,14 +257,10 @@ version: 3.0.0-rc.6
                 }
 
                 if (this.defaultComposition) {
-                    return this._renderCompositionChange(this.defaultComposition, () => {
-                        return this.defaultComposition.cloneNode(true);
-                    });
+                    return this._renderCompositionChange(this.defaultComposition, () => this.defaultComposition.cloneNode(true));
                 }
                 
-                return this._renderCompositionChange("explicit or fallback", () => {
-                    return undefined;
-                });
+                return this._renderCompositionChange("explicit or fallback", () => undefined);
             }            
         };
         /**

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -86,8 +86,6 @@ version: 3.0.0-rc.6
         StarcounterIncludePrototype.shadow = useShadowDOMV1;
         StarcounterIncludePrototype.partial = null;
         StarcounterIncludePrototype.partialId = null;
-        //FIXME: this one should not be needed, once we get rid of workarounds for server-side
-        StarcounterIncludePrototype.compositionAPI = '/sc/partial/composition';
         // StarcounterIncludePrototype.href = null;
         StarcounterIncludePrototype.mergedHtmlPrefix = '/sc/htmlmerger?';
         StarcounterIncludePrototype.defaultHtml = '';

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -113,7 +113,7 @@ version: 3.0.0-rc.6
             var starcounterInclude = this;
             var partialId = this.partialId;
             var partial = this.viewModel || this.partial || undefined;
-            checkForNonNamesapced(partial, this);
+            checkForNonNamespaced(partial, this);
 
             // build shadow DOM
             if(useShadowDOMV1){
@@ -130,7 +130,7 @@ version: 3.0.0-rc.6
                 partial: {
                     set: function(newValue) {
                         partial = newValue;
-                        checkForNonNamesapced(partial, this);
+                        checkForNonNamespaced(partial, this);
                         starcounterInclude.stampImportedTemplate();
                         starcounterInclude.partialChanged(partial);
                     },
@@ -393,7 +393,7 @@ version: 3.0.0-rc.6
          * @param  {Object} viewModel view-model to check
          * @param  {HTMLElement} element starcounter-include to point to
          */
-        function checkForNonNamesapced(viewModel, element){
+        function checkForNonNamespaced(viewModel, element){
             if(viewModel && typeof viewModel.Html !== 'undefined'){
                 console.warn(`Your view-model is probably not namespaced!
 `, viewModel, `

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -218,6 +218,7 @@ version: 3.0.0-rc.6
             if (!this._forceLayoutChange && this._lastCompositionRef == compositionRef) {
                 return;
             }
+            this.storedLayout = null;
             let composition = callb();
             this.stampComposition(composition);
             this._forceLayoutChange = false;
@@ -236,7 +237,7 @@ version: 3.0.0-rc.6
         StarcounterIncludePrototype._compositionChanged = function(compositionString) {
             var that = this;
 
-            if (compositionString !== undefined) {
+            if (compositionString) {
                 this._forceLayoutChange = true;
                 this._renderCompositionChange("explicit or fallback", function() {
                     return that.stringToDocumentFragment(compositionString);
@@ -245,6 +246,11 @@ version: 3.0.0-rc.6
             else {
                 const compositionProvider = this.partial && findCompositionProvider(this.partial);
                 this.partialId = compositionProvider && compositionProvider.PartialId;
+
+                if (compositionProvider && compositionProvider.Composition$ && compositionString === "") {
+                    //this is a request from starcounter-layout-html-editor to reset to default composition
+                    that.Composition$ = "";
+                }
 
                 if (compositionProvider && compositionProvider.Composition$) {
                     this._renderCompositionChange(compositionProvider.Composition$, function() {

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -211,17 +211,17 @@ version: 3.0.0-rc.6
 
         /**
          * Stamps composition if needed
-         * @param  {String} compositionString HTML as a string to compare if a re-render is needed
+         * @param  {String|DocumentFragment} compositionRef reference to the evaluated composition
          * @param  {Function} callb Function that returns a composition to render
          */
-        StarcounterIncludePrototype._renderCompositionChange = function(compositionString, callb) {
-            if (!this._forceLayoutChange && this._lastCompositionString == compositionString) {
+        StarcounterIncludePrototype._renderCompositionChange = function(compositionRef, callb) {
+            if (!this._forceLayoutChange && this._lastCompositionRef == compositionRef) {
                 return;
             }
             let composition = callb();
             this.stampComposition(composition);
             this._forceLayoutChange = false;
-            this._lastCompositionString = compositionString;
+            this._lastCompositionRef = compositionRef;
         }
 
         /**
@@ -253,7 +253,7 @@ version: 3.0.0-rc.6
                     });
                 }
                 else if (this.defaultComposition) {
-                    this._renderCompositionChange("imported template's default", function() {
+                    this._renderCompositionChange(this.defaultComposition, function() {
                         return that.defaultComposition.cloneNode(true);
                     });
                 }

--- a/test/composition/declarative-shadow-dom.html
+++ b/test/composition/declarative-shadow-dom.html
@@ -73,7 +73,7 @@
             // scInclude.partial = JSON.parse(JSON.stringify(partial));
             setTimeout(done, 500);
         });
-        it('should use it as it\'s composition', function () {
+        it('should use it as its composition', function () {
             expect(scInclude.shadowRoot).to.be.not.null;
             expect(scInclude.shadowRoot.innerHTML.trim()).to.be
                 .equal(document.querySelector(REFERENCE_COMPOSITION).innerHTML.trim());
@@ -83,7 +83,7 @@
                 scInclude.partial = JSON.parse(JSON.stringify(alternativePartial));
                 setTimeout(done, 500);
             });
-            it('should use it as it\'s composition', function () {
+            it('should use it as its composition', function () {
                 expect(scInclude.shadowRoot).to.be.not.null;
                 expect(scInclude.shadowRoot.innerHTML.trim()).to.be
                     .equal(document.querySelector(REFERENCE_ALTERNATIVE_COMPOSITION).innerHTML.trim());

--- a/test/composition/declarative-shadow-dom.html
+++ b/test/composition/declarative-shadow-dom.html
@@ -89,6 +89,20 @@
                     .equal(document.querySelector(REFERENCE_ALTERNATIVE_COMPOSITION).innerHTML.trim());
             });
         });
+        describe('after composition is changed from default to explicit', function () {
+            var explicitComposition = "explicit composition";
+            beforeEach(function () {
+                scInclude._compositionChanged(explicitComposition);
+            });
+            it('should render the explicit composition', function () {
+                expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(explicitComposition);
+            });
+            it('should return to default after resetting', function () {
+                scInclude._compositionChanged(""); //this is how starcounter-layout-html-editor resets
+                expect(scInclude.shadowRoot.innerHTML.trim()).to.be
+                    .equal(document.querySelector(REFERENCE_COMPOSITION).innerHTML.trim());
+            });
+        });
         describe('after partial property is replaced with itself', function () {
             it('should keep using the existing composition', function (done) { //otherwise ViewKeeper (aka workspaces) do not keep state in Firefox and Edge
                 var old  = scInclude.shadowRoot.querySelector("h2");

--- a/test/composition/declarative-shadow-dom.html
+++ b/test/composition/declarative-shadow-dom.html
@@ -32,11 +32,19 @@
     </test-fixture>
     <template id="reference-composition">
         <h2>Custom Shadow DOM composition</h2>
-		<slot name="my-slot"></slot>
+        <slot name="my-slot"></slot>
+    </template>
+    <template id="reference-alternative-composition">
+        <h2>Custom Shadow DOM alternative composition</h2>
+        <slot name="my-slot"></slot>
     </template>
     <template id="reference-composition-v1-to-v0">
         <h2>Custom Shadow DOM composition</h2>
-		<content name="my-slot" select="[slot='my-slot']"></content>
+        <content name="my-slot" select="[slot='my-slot']"></content>
+    </template>
+    <template id="reference-alternative-composition-v1-to-v0">
+        <h2>Custom Shadow DOM alternative composition</h2>
+        <content name="my-slot" select="[slot='my-slot']"></content>
     </template>
 
 
@@ -44,14 +52,15 @@
     describe('starcounter-include when imports a template that contains <code>template is="declarative-shadow-dom"</code>', function () {
         const useShadowDOMV1 = Boolean(Element.prototype.attachShadow && Node.prototype.getRootNode);
         const REFERENCE_COMPOSITION = useShadowDOMV1 ? '#reference-composition' : '#reference-composition-v1-to-v0'
+        const REFERENCE_ALTERNATIVE_COMPOSITION = useShadowDOMV1 ? '#reference-alternative-composition' : '#reference-alternative-composition-v1-to-v0'
 
         var scInclude;
-        var partial = {
+        var alternativePartial = {
             "CompositionProvider": {
                 "PartialId": "given PartialId"
             },
             "App": {
-                "Html": "template_w_declarative-shadow-dom.html",
+                "Html": "template_w_declarative-shadow-dom-alternative.html",
                 "doesItWork": "works!"
             }
         };
@@ -71,13 +80,13 @@
         });
         describe('after partial property is replaced with the partial that also does contain default composition', function () {
             beforeEach(function (done) {
-                scInclude.partial = JSON.parse(JSON.stringify(partial));
+                scInclude.partial = JSON.parse(JSON.stringify(alternativePartial));
                 setTimeout(done, 500);
             });
             it('should use it as it\'s composition', function () {
                 expect(scInclude.shadowRoot).to.be.not.null;
                 expect(scInclude.shadowRoot.innerHTML.trim()).to.be
-                    .equal(document.querySelector(REFERENCE_COMPOSITION).innerHTML.trim());
+                    .equal(document.querySelector(REFERENCE_ALTERNATIVE_COMPOSITION).innerHTML.trim());
             });
         });
         describe('after partial property is replaced with itself', function () {

--- a/test/composition/starcounter-composition.html
+++ b/test/composition/starcounter-composition.html
@@ -66,7 +66,7 @@
             // scInclude.partial = JSON.parse(JSON.stringify(partial));
             setTimeout(done, 500);
         });
-        it('should use it as it\'s composition', function () {
+        it('should use it as its composition', function () {
             expect(scInclude.shadowRoot).to.be.not.null;
             expect(scInclude.shadowRoot.innerHTML.trim()).to.be
                 .equal(document.querySelector(REFERENCE_COMPOSITION).innerHTML.trim());
@@ -80,7 +80,7 @@
                 scInclude.partial = JSON.parse(JSON.stringify(partial));
                 setTimeout(done, 500);
             });
-            it('should use it as it\'s composition', function () {
+            it('should use it as its composition', function () {
                 expect(scInclude.shadowRoot).to.be.not.null;
                 expect(scInclude.shadowRoot.innerHTML.trim()).to.be
                     .equal(document.querySelector(REFERENCE_COMPOSITION).innerHTML.trim());

--- a/test/partialAttribute/nested-html/stamped_from_polymer_template.html
+++ b/test/partialAttribute/nested-html/stamped_from_polymer_template.html
@@ -185,7 +185,7 @@
                 });
             });
 
-            describe('after `dom-bind` re-set the sub-partial property (just one scope) to the same instance but potentially with new values', function () {
+            describe('after `dom-bind` re-set the sub-partial property (just one scope) to the same instance', function () {
                 var scope;
 
                 beforeEach(function(done) {

--- a/test/partialAttribute/nested-html/stamped_from_polymer_template.html
+++ b/test/partialAttribute/nested-html/stamped_from_polymer_template.html
@@ -222,7 +222,7 @@
                     expect(importedTemplate._notifyPath).to.be.calledWith("model.scope1.doesItWork", newVal);
                 });
 
-                it('should be preserve the explicit composition', function () {
+                it('should preserve the explicit composition', function () {
                     expect(include.shadowRoot.innerHTML).to.be.equal(customComposition);
                 });
             });

--- a/test/partialAttribute/nested-html/stamped_from_polymer_template.html
+++ b/test/partialAttribute/nested-html/stamped_from_polymer_template.html
@@ -204,6 +204,29 @@
                 });
             });
 
+            describe('after `dom-bind` changes the sub-partial property of a view with an explicit composition', function () {
+                var scope, include, newVal = "yeah", customComposition = "my custom composition";
+
+                beforeEach(function(done) {
+                    sinon.stub(importedTemplate, "_notifyPath");
+                    importedTemplate.addEventListener('stamping', function onceStamped(){
+                        importedTemplate.removeEventListener('stamping', onceStamped);                   
+                        include = container.querySelector('starcounter-include');
+                        include._compositionChanged(customComposition); //this is how starcounter-layout-html-editor uses it
+                        domBind.set('model.Page.scope1.doesItWork', newVal);
+                        done();
+                    });
+                });
+
+                it('should forward the notification to `imported-template`', function () {
+                    expect(importedTemplate._notifyPath).to.be.calledWith("model.scope1.doesItWork", newVal);
+                });
+
+                it('should be preserve the explicit composition', function () {
+                    expect(include.shadowRoot.innerHTML).to.be.equal(customComposition);
+                });
+            });
+
             describe('after `dom-bind`` changed the sub-partial property (just one scope) to new one with thethat results with the same merged Html', function () {
                 var changedScopeWithSameHtml;
                 beforeEach(function(done) {


### PR DESCRIPTION
PR #60 introduced a significant regression in using CompositionEditor. This was due to multiple ways to use `_compositionChanged` as a public method, which was not tested.

This PR adds all the fixes that I could provide based on my smoke tests and a test for each fix.

There are two significant code removals:

- https://github.com/Starcounter/starcounter-include/commit/1adb7fe8b48c9aa48245997aaad4b5e62fc1d39e removes most of the code from `_notifyPath`
- https://github.com/Starcounter/starcounter-include/commit/215d6cf745fec321c9a6a2859598ba873749ff7f removes most of the code from `saveLayout`

@alshakero pls review.

@tomalec FYI. You can post-review after you're back from TPAC.