### PR TITLE
fix the flow (#71, #75) make more tests pass

### DIFF
--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -230,7 +230,14 @@ version: 4.0.1
                 }
             }
         }
-
+        /**
+         * @deprecated Use `starcounterInclude.shadowRoot` or `viewModel.{CompositionProvider}.Composition$`
+         * @alias #updateComposition
+         */
+        StarcounterIncludePrototype._compositionChanged = function(compositionString) {
+            console.warn('_compositionChanged, was renamed to updateComposition. Most probably you don\'t even need to use it. In most of the cases `starcounterInclude.shadowRoot` or changing the `viewModel.{CompositionProvider}.Composition$` should do the right thing.');
+            return this.updateComposition(compositionString);
+        };
         /**
          * Handles change of the composition.
          * If not given explicitely, fetches one from provider.

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -32,13 +32,74 @@ version: 4.0.1
             static get observedAttributes() {
                 return ['partial', 'view-model', 'partialId'];
             }
-            // the self argument might be provided or not
-            // in both cases, the mandatory `super()` call
-            // will return the right context/instance to use
-            // and eventually return
-            constructor(self) {
-                self = super(self);
-                this.createComponent();
+            /**
+            * Create shadowRoot, define property setters, set initial partial.
+            */
+            constructor() {
+                super();
+                this.defaultComposition = null;
+                var partialId = this.partialId;
+                var partial = this.viewModel || this.partial || undefined;
+                checkForNonNamespaced(partial, this);
+
+                // build shadow DOM
+                if(useShadowDOMV1){
+                    this.attachShadow({mode: "open"});
+                } else {
+                    this.createShadowRoot();
+                }
+                // stamp composition
+                // like this.stampComposition() without an event
+                this.shadowRoot.innerHTML = defaultShadowCSS + defaultShadowDOM;
+
+                // define a setter for partial attribute,
+                // so it could be change by VanillaJs without Polymer Template Binding
+                Object.defineProperties(this, {
+                    partial: {
+                        set: function(newValue) {
+                            partial = newValue;
+                            checkForNonNamespaced(partial, this);
+                            if(!this.template){
+                                // stamp imported tempalte attach href, and eventually model
+                                this.stampImportedTemplate();
+                            } else {
+                                // just update href and model ONLY if there is no href change
+                                if(!this._updateHref()){
+                                    this.template.model = this.partial;
+                                }
+                            }
+                            // update composition, use custom one until content is fetched to avoid FOUC
+                            this.updateComposition();
+                        },
+                        get: function() {
+                            return partial;
+                        }
+                    },
+                    viewModel: {
+                        set: function(newValue) {
+                            this.partial = newValue;
+                        },
+                        get: function() {
+                            return this.partial;
+                        }
+                    },
+                    partialId: {
+                        set: function(newValue) {
+                            // do nothing if value is the same or null is being changed to undefined
+                            if (newValue != partialId) {
+                                partialId = newValue || null;
+                                if (!partialId) {
+                                    this.removeAttribute("partial-id");
+                                } else {
+                                    this.setAttribute("partial-id", partialId);
+                                }
+                            }
+                        },
+                        get: function() {
+                            return partialId;
+                        }
+                    }
+                });
             }
             /**
              * Stamp `imported-template` into Light DOM,
@@ -64,16 +125,16 @@ version: 4.0.1
                         }
                         starcounterInclude.defaultComposition = mergedComposition;
 
-                        if (this.model != starcounterInclude.partial) {
-                            this.model = starcounterInclude.partial
+                        if (this.model !== starcounterInclude.partial) {
+                            // update entire model
+                            this.model = starcounterInclude.partial;
                         }
-                        // notify composition property
-                        // TODO: consider moving entire partialChanged or appendChild here
-                        starcounterInclude._compositionChanged();
+                        // put correct composition
+                        starcounterInclude.updateComposition();
                     });
 
                     const href = buildURL(this.partial, this.mergedHtmlPrefix, this.defaultHtml);
-                    href && (importedTemplate.href = href); 
+                    href && (importedTemplate.href = href);
 
                     this.appendChild(importedTemplate);
                     this.template = importedTemplate;
@@ -107,67 +168,6 @@ version: 4.0.1
             }
         }
         /**
-         * Create shadowRoot, define property setters, set unitial partial.
-         */
-        StarcounterIncludePrototype.createComponent = function StarcounterIncludeCreated() {
-            var starcounterInclude = this;
-            this.defaultComposition = null;
-            var partialId = this.partialId;
-            var partial = this.viewModel || this.partial || undefined;
-            checkForNonNamespaced(partial, this);
-
-            // build shadow DOM
-            if(useShadowDOMV1){
-                this.attachShadow({mode: "open"});
-            } else {
-                this.createShadowRoot();
-            }
-            // partialChanged will do
-            // this.stampComposition();
-
-            // define a setter for partial attribute,
-            // so it could be change by VanillaJs without Polymer Template Binding
-            Object.defineProperties(this, {
-                partial: {
-                    set: function(newValue) {
-                        partial = newValue;
-                        checkForNonNamespaced(partial, this);
-                        starcounterInclude.stampImportedTemplate();
-                        starcounterInclude.partialChanged(partial);
-                    },
-                    get: function() {
-                        return partial;
-                    }
-                },
-                viewModel: {
-                    set: function(newValue) {
-                        this.partial = newValue;
-                    },
-                    get: function() {
-                        return this.partial;
-                    }
-                },
-                partialId: {
-                    set: function(newValue) {
-                        // do nothing if value is the same or null is being changed to undefined
-                        if (newValue != partialId) {
-                            partialId = newValue || null;
-                            if (!partialId) {
-                                this.removeAttribute("partial-id");
-                            } else {
-                                this.setAttribute("partial-id", partialId);
-                            }
-                        }
-                    },
-                    get: function() {
-                        return partialId;
-                    }
-                }
-            });
-            // attach partial
-            this.partialChanged();
-        };
-        /**
          * Set partial property if partial or viewm-model attribute was changed
          */
         StarcounterIncludePrototype.attributeChangedCallback = function(name, oldVal, newVal) {
@@ -177,15 +177,14 @@ version: 4.0.1
             }
         };
         /**
-         * Updates inner `imported-template` with partial data given (if applicable)
-         * @see Starcounter/starcounter-include#partialChanged it's alsmost a copy
-         * @param  {Object} newVal new partial value
+         * Builds merged HTML URL.
+         * If the URL is different than previous importedTemplate.href,
+         * cleares the template and #defaultComposition, then updates it.
+         * TODO: Check if merged HTML URL should be changed,
+         * Check if needed: Does nothing if there is no template
+         * @returns {Boolean} was the href changed?
          */
-        StarcounterIncludePrototype.partialChanged = function(newVal) {
-            this._htmlChanged();
-            this._compositionChanged();
-        };
-        StarcounterIncludePrototype._htmlChanged = function() {
+        StarcounterIncludePrototype._updateHref = function() {
             // do nothing if there is no tempalte yet
             if(!this.template){
                 return;
@@ -196,16 +195,11 @@ version: 4.0.1
                     this.defaultComposition = null;
                     this.template.clear();
                 }
-                if (!href) {
-                    this.template.href = null;
-                    if (this.template.model != this.partial) {
-                        this.template.model = this.partial
-                    }
-                } else {
-                    this.template.href = href;
-                }
-            } else if (this.template.model != this.partial) {
-                this.template.model = this.partial
+                // set the new value, unify falsy to null
+                this.template.href = href || null;
+                return true;
+            } else {
+                return false;
             }
         };
 
@@ -246,7 +240,7 @@ version: 4.0.1
          * @see .stampComposition
          * @param  {String} compositionString stringified HTML for new Shadow Root
          */
-        StarcounterIncludePrototype._compositionChanged = function(compositionString) {
+        StarcounterIncludePrototype.updateComposition = function(compositionString) {
             if (compositionString) {
                 this.explicitComposition = compositionString;
                 return this._renderCompositionChange(compositionString, () => this.stringToDocumentFragment(compositionString));
@@ -316,13 +310,55 @@ version: 4.0.1
         * @param  {Mixed} value New value
         */
         StarcounterIncludePrototype._setPendingPropertyOrPath = function (path, value) {
-            var sameModelAlreadyLoaded = this.template.model == this.partial;
-            this.partialChanged(this.partial);
-            if (sameModelAlreadyLoaded && this.template._setPendingPropertyOrPath) {
-                this.template._setPendingPropertyOrPath(
-                    path.replace("partial.", "model.")
-                        .replace("viewModel.", "model."),
-                     value);
+
+            var sameModelAlreadyLoaded = this.template.model === this.partial;
+            const newPath = path.replace("partial.", "model.")
+                .replace("viewModel.", "model.");
+            // If that's the same model, we still may need to bump
+            if(sameModelAlreadyLoaded){
+                // yey we still support both names, lets strip one or another.
+                const subPath = (path.indexOf('partial.') === 0) && path.substr(8) ||
+                                (path.indexOf('viewModel.') === 0) && path.substr(10);
+                // check indexOf to optimeze match performance
+                const dotPos = subPath.indexOf('.');
+                // Update html and composition if needed
+                if (
+                    // it's a change of entire sub-partial
+                    dotPos === -1
+                ){
+                    // update href (when changed it will re-stamp and set the model by itself)
+                    if(!this._updateHref()){
+                        // Notify about model change
+                        if (this.template._setPendingPropertyOrPath) {
+                            this.template._setPendingPropertyOrPath(newPath, value);
+                        }
+                        // There is no chance that composition changed by changing just Apps model
+                        // TODO: unless it's Composition Provider add a test for a change for just model.CompositionProvider_0
+                    }
+                    return ;
+                }
+                else if (
+                    // it's sub-partial's .Html
+                    // subPath.matches(/[^\.]\.Html/)
+                    subPath.indexOf('.Html') === subPath.length - 5 &&
+                    dotPos === subPath.lastIndexOf('.')
+                ){
+                    this._updateHref();
+                    return;
+                }
+                // TODO: handle just composition change add a test for a change for just model.CompositionProvider_0.Composition$
+                // Notify about model change
+                if (this.template._setPendingPropertyOrPath) {
+                    this.template._setPendingPropertyOrPath(newPath, value);
+                }
+            } else {
+                // this.partialChanged(this.partial);
+                // Complately new partial, reload everything
+                // TODO: check if we can even get to this point
+                if(!this._updateHref()){
+                    this.template.model = this.partial;
+                }
+                this.updateComposition();
             }
         };
         /**
@@ -366,7 +402,7 @@ version: 4.0.1
             }
         };
         /**
-         * Saves given or current composition as stored one, (TODO:) notifies binding about it.
+         * Saves given or current composition as stored one, notifies binding about it.
          * @param  {String} [compositionStr] composition to be saved, if not given current one will be used
          * @TODO: to be simplified after https://github.com/StarcounterApps/CompositionProvider/pull/13 is done
          */

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -179,7 +179,7 @@ version: 4.0.1
         /**
          * Builds merged HTML URL.
          * If the URL is different than previous importedTemplate.href,
-         * cleares the template and #defaultComposition, then updates it.
+         * clears the template and #defaultComposition, then updates it.
          * TODO: Check if merged HTML URL should be changed,
          * Check if needed: Does nothing if there is no template
          * @returns {Boolean} was the href changed?
@@ -317,9 +317,9 @@ version: 4.0.1
             // If that's the same model, we still may need to bump
             if(sameModelAlreadyLoaded){
                 // yey we still support both names, lets strip one or another.
-                const subPath = (path.indexOf('partial.') === 0) && path.substr(8) ||
-                                (path.indexOf('viewModel.') === 0) && path.substr(10);
-                // check indexOf to optimeze match performance
+                const subPath = path.startsWith('partial.') && path.substr(8) ||
+                                path.startsWith('viewModel.') && path.substr(10);
+                // check indexOf to optimize match performance
                 const dotPos = subPath.indexOf('.');
                 // Update html and composition if needed
                 if (
@@ -340,7 +340,7 @@ version: 4.0.1
                 else if (
                     // it's sub-partial's .Html
                     // subPath.matches(/[^\.]\.Html/)
-                    subPath.indexOf('.Html') === subPath.length - 5 &&
+                    subPath.endsWith('.Html') &&
                     dotPos === subPath.lastIndexOf('.')
                 ){
                     this._updateHref();
@@ -353,7 +353,7 @@ version: 4.0.1
                 }
             } else {
                 // this.partialChanged(this.partial);
-                // Complately new partial, reload everything
+                // Completely new partial, reload everything
                 // TODO: check if we can even get to this point
                 if(!this._updateHref()){
                     this.template.model = this.partial;

--- a/test/composition/custom.html
+++ b/test/composition/custom.html
@@ -74,13 +74,13 @@
                 var explicitComposition = "explicit composition";
                 beforeEach(function () {
                     composition$ = scInclude.viewModel.CompositionProvider.Composition$;
-                    scInclude._compositionChanged(explicitComposition);
+                    scInclude.updateComposition(explicitComposition);
                 });
                 it('should render the explicit composition', function () {
                     expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(explicitComposition);
                 });
                 it('should return to default after resetting', function () {
-                    scInclude._compositionChanged(""); //this is how starcounter-layout-html-editor resets
+                    scInclude.updateComposition(""); //this is how starcounter-layout-html-editor resets
 
                     expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString(REFERENCE_DEFAULT);
                 });
@@ -90,7 +90,7 @@
                 describe('after saveLayout() is called', function () {
                     beforeEach(function () {
                         scInclude.saveLayout();
-                        scInclude._compositionChanged(); //simulate notifyPath which can trigger _compositionChanged
+                        scInclude.updateComposition(); //simulate notifyPath which can trigger updateComposition
                     });
                     it('should overwrite Composition$', function () {
                         expect(scInclude.viewModel.CompositionProvider.Composition$.trim()).to.be.equal(explicitComposition);

--- a/test/composition/default-declarative-shadow-dom.html
+++ b/test/composition/default-declarative-shadow-dom.html
@@ -111,13 +111,13 @@
             var explicitComposition = "explicit composition";
             beforeEach(function() {
                 composition$ = scInclude.viewModel.CompositionProvider.Composition$;
-                scInclude._compositionChanged(explicitComposition);
+                scInclude.updateComposition(explicitComposition);
             });
             it('should render the explicit composition', function() {
                 expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(explicitComposition);
             });
             it('should return to default after resetting', function() {
-                scInclude._compositionChanged(""); //this is how starcounter-layout-html-editor resets
+                scInclude.updateComposition(""); //this is how starcounter-layout-html-editor resets
                 expect(scInclude.shadowRoot.innerHTML).to.be
                     .sameHTMLString(REFERENCE_COMPOSITION);
             });
@@ -127,7 +127,7 @@
             describe('after saveLayout() is called', function() {
                 beforeEach(function() {
                     scInclude.saveLayout();
-                    scInclude._compositionChanged(); //simulate notifyPath which can trigger _compositionChanged
+                    scInclude.updateComposition(); //simulate notifyPath which can trigger updateComposition
                 });
                 it('should overwrite Composition$', function() {
                     expect(scInclude.viewModel.CompositionProvider.Composition$.trim()).to.be.equal(explicitComposition);
@@ -152,13 +152,13 @@
                 var explicitComposition = "explicit composition";
                 beforeEach(function() {
                     composition$ = scInclude.viewModel.CompositionProvider.Composition$;
-                    scInclude._compositionChanged(explicitComposition);
+                    scInclude.updateComposition(explicitComposition);
                 });
                 it('should render the explicit composition', function() {
                     expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(explicitComposition);
                 });
                 it('should return to default after resetting', function() {
-                    scInclude._compositionChanged(""); //this is how starcounter-layout-html-editor resets
+                    scInclude.updateComposition(""); //this is how starcounter-layout-html-editor resets
                     expect(scInclude.shadowRoot.innerHTML).to.be
                         .sameHTMLString(REFERENCE_COMPOSITION + REFERENCE_ALTERNATIVE_COMPOSITION);
                 });
@@ -168,7 +168,7 @@
                 describe('after saveLayout() is called', function() {
                     beforeEach(function() {
                         scInclude.saveLayout();
-                        scInclude._compositionChanged(); //simulate notifyPath which can trigger _compositionChanged
+                        scInclude.updateComposition(); //simulate notifyPath which can trigger updateComposition
                     });
                     it('should overwrite Composition$', function() {
                         expect(scInclude.viewModel.CompositionProvider.Composition$.trim()).to.be.equal(explicitComposition);

--- a/test/composition/fallback.html
+++ b/test/composition/fallback.html
@@ -72,13 +72,13 @@
         describe('after composition is changed to explicit', function() {
             var explicitComposition = "explicit composition";
             beforeEach(function() {
-                scInclude._compositionChanged(explicitComposition);
+                scInclude.updateComposition(explicitComposition);
             });
             it('should render the explicit composition', function() {
                 expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(explicitComposition);
             });
             it('should return to fallback after resetting', function() {
-                scInclude._compositionChanged(""); //this is how starcounter-layout-html-editor resets
+                scInclude.updateComposition(""); //this is how starcounter-layout-html-editor resets
                 expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(REFERENCE_FALLBACK);
             });
             it('should NOT overwrite Composition$', function() {
@@ -87,7 +87,7 @@
             describe('after saveLayout() is called', function() {
                 beforeEach(function() {
                     scInclude.saveLayout();
-                    scInclude._compositionChanged(); //simulate notifyPath which can trigger _compositionChanged
+                    scInclude.updateComposition(); //simulate notifyPath which can trigger updateComposition
                 });
                 it('should overwrite Composition$', function() {
                     expect(scInclude.viewModel.CompositionProvider.Composition$.trim()).to.be.equal(explicitComposition);

--- a/test/partialAttribute/nested-html/stamped_from_polymer_template.html
+++ b/test/partialAttribute/nested-html/stamped_from_polymer_template.html
@@ -44,6 +44,7 @@
                 }
             };
         };
+        const MERGED_URL = '/sc/htmlmerger?scope1=scope1Html&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=';
         var changedPartial = {
             'scopeA': {
                 'Html': 'scopeAHtml',
@@ -82,8 +83,8 @@
             });
 
             it('should attach concatenated `Html` properties as href attribute and property for `<imported-template>`', function () {
-                expect(importedTemplate.getAttribute("href")).to.equal('/sc/htmlmerger?scope1=scope1Html&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
-                expect(importedTemplate.href).to.equal('/sc/htmlmerger?scope1=scope1Html&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
+                expect(importedTemplate.getAttribute("href")).to.equal(MERGED_URL);
+                expect(importedTemplate.href).to.equal(MERGED_URL);
             });
             it('should NOT attach partial model to `imported-template` immediately', function () {
                 expect(importedTemplate.model).to.equal(null);
@@ -160,8 +161,8 @@
                     });
 
                     it('should attach new `.Html` property as href attribute and propery for `<imported-template>`', function () {
-                        expect(importedTemplate.getAttribute("href")).to.equal('/sc/htmlmerger?scope1=scope1Html&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
-                        expect(importedTemplate.href).to.equal('/sc/htmlmerger?scope1=scope1Html&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
+                        expect(importedTemplate.getAttribute("href")).to.equal(MERGED_URL);
+                        expect(importedTemplate.href).to.equal(MERGED_URL);
                     });
                     it('should attach new partial model to `imported-template` immediately', function () {
                         expect(importedTemplate.model).to.equal(changedPartialWithSameHtml);
@@ -215,7 +216,7 @@
                         sinon.stub(importedTemplate, "_setPendingPropertyOrPath");
                         include = container.querySelector('starcounter-include');
                         // TODO: do we really want to tangle starcounter-layout-html-editor in the case that should be atomic as well?
-                        include._compositionChanged(customComposition); //this is how starcounter-layout-html-editor uses it
+                        include.updateComposition(customComposition); //this is how starcounter-layout-html-editor uses it
                         shadowRoot = include.shadowRoot;
                         domBind.set('model.Page.scope1.doesItWork', newVal);
                     });
@@ -244,8 +245,8 @@
                     });
 
                     it('should keep same `.Html` property as href attribute and propery for `<imported-template>`', function () {
-                        expect(importedTemplate.getAttribute("href")).to.equal('/sc/htmlmerger?scope1=scope1Html&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
-                        expect(importedTemplate.href).to.equal('/sc/htmlmerger?scope1=scope1Html&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
+                        expect(importedTemplate.getAttribute("href")).to.equal(MERGED_URL);
+                        expect(importedTemplate.href).to.equal(MERGED_URL);
                     });
                     it('should attach new partial model to `imported-template` immediately', function () {
                         expect(importedTemplate.model.scope1).to.equal(changedScopeWithSameHtml);

--- a/test/partialAttribute/nested-html/stamped_from_polymer_template.html
+++ b/test/partialAttribute/nested-html/stamped_from_polymer_template.html
@@ -111,38 +111,38 @@
                     done();
                 });
             });
-
-            describe('after `dom-bind`` changed the partial property', function () {
-                beforeEach(function(done) {
+            describe('and nodes were stamped', function(){
+                beforeEach((done)=>{
                     // IDEA: promisify juicy-html
                     importedTemplate.addEventListener('stamping', function onceStamped(){
                         importedTemplate.removeEventListener('stamping', onceStamped);
+                        done();
+                    });
+                });
+
+                describe('after `dom-bind`` changed the partial property', function () {
+                    beforeEach(function() {
                         domBind.set('model.Page', changedPartial);
-                        done();
+                    });
+
+                    it('should attach new `.Html` property as href attribute and property for `<imported-template>`', function () {
+                        expect(importedTemplate.getAttribute("href")).to.equal('/sc/htmlmerger?scopeA=scopeAHtml&scopeB=scopeBHtml');
+                        expect(importedTemplate.href).to.equal('/sc/htmlmerger?scopeA=scopeAHtml&scopeB=scopeBHtml');
+                    });
+                    it('should NOT attach new partial model to `imported-template` immediately', function () {
+                        expect(importedTemplate.model).to.equal(partial);
+                    });
+                    it('should attach new partial model to `imported-template` on `stamping`', function (done) {
+                        importedTemplate.addEventListener('stamping', function onceStamped(){
+                            expect(importedTemplate.model).to.equal(changedPartial);
+                            done();
+                        });
                     });
                 });
 
-                it('should attach new `.Html` property as href attribute and property for `<imported-template>`', function () {
-                    expect(importedTemplate.getAttribute("href")).to.equal('/sc/htmlmerger?scopeA=scopeAHtml&scopeB=scopeBHtml');
-                    expect(importedTemplate.href).to.equal('/sc/htmlmerger?scopeA=scopeAHtml&scopeB=scopeBHtml');
-                });
-                it('should NOT attach new partial model to `imported-template` immediately', function () {
-                    expect(importedTemplate.model).to.equal(partial);
-                });
-                it('should attach new partial model to `imported-template` on `stamping`', function (done) {
-                    importedTemplate.addEventListener('stamping', function onceStamped(){
-                        expect(importedTemplate.model).to.equal(changedPartial);
-                        done();
-                    });
-                });
-            });
-
-            describe('after `dom-bind`` changed the partial property to new one with the same Html', function () {
-                var changedPartialWithSameHtml;
-                beforeEach(function(done) {
-                    // IDEA: promisify juicy-html
-                    importedTemplate.addEventListener('stamping', function onceStamped(){
-                        importedTemplate.removeEventListener('stamping', onceStamped);
+                describe('after `dom-bind`` changed the partial property to new one with the same Html', function () {
+                    var changedPartialWithSameHtml;
+                    beforeEach(function() {
                         changedPartialWithSameHtml = {
                             'scope1': {
                                 'Html': 'scope1Html',
@@ -157,147 +157,140 @@
                             }
                         };
                         domBind.set('model.Page', changedPartialWithSameHtml);
-                        done();
+                    });
+
+                    it('should attach new `.Html` property as href attribute and propery for `<imported-template>`', function () {
+                        expect(importedTemplate.getAttribute("href")).to.equal('/sc/htmlmerger?scope1=scope1Html&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
+                        expect(importedTemplate.href).to.equal('/sc/htmlmerger?scope1=scope1Html&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
+                    });
+                    it('should attach new partial model to `imported-template` immediately', function () {
+                        expect(importedTemplate.model).to.equal(changedPartialWithSameHtml);
                     });
                 });
 
-                it('should attach new `.Html` property as href attribute and propery for `<imported-template>`', function () {
-                    expect(importedTemplate.getAttribute("href")).to.equal('/sc/htmlmerger?scope1=scope1Html&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
-                    expect(importedTemplate.href).to.equal('/sc/htmlmerger?scope1=scope1Html&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
-                });
-                it('should attach new partial model to `imported-template` immediately', function () {
-                    expect(importedTemplate.model).to.equal(changedPartialWithSameHtml);
-                });
-            });
-
-            describe('after `dom-bind`` changed the sub-partial property (just one scope)', function () {
-                var changedScope;
-                beforeEach(function(done) {
-                    // IDEA: promisify juicy-html
-                    importedTemplate.addEventListener('stamping', function onceStamped(){
-                        importedTemplate.removeEventListener('stamping', onceStamped);
+                describe('after `dom-bind`` changed the sub-partial (just one scope), to a one that results in different merged Html', function () {
+                    var changedScope;
+                    beforeEach(function() {
+                        sinon.stub(importedTemplate, "_setPendingPropertyOrPath");
                         changedScope = JSON.parse(JSON.stringify(changedPartial.scopeA));
                         domBind.set('model.Page.scope1', changedScope);
-                        done();
+                    });
+
+                    it('should attach new `.Html` property as href attribute and property for `<imported-template>`', function () {
+                        expect(importedTemplate.getAttribute("href")).to.equal('/sc/htmlmerger?scope1=scopeAHtml&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
+                        expect(importedTemplate.href).to.equal('/sc/htmlmerger?scope1=scopeAHtml&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
+                    });
+                    it('should NOT attach new partial model to `imported-template` immediately', function () {
+                        expect(importedTemplate.model).to.equal(partial);
+                    });
+                    it('should NOT notify `imported-template` (old nodes) with the new model changes immediately', function () {
+                        expect(importedTemplate._setPendingPropertyOrPath).not.to.be.called;
+                    });
+                    it('should attach new partial model to `imported-template` on `stamping`', function (done) {
+                        importedTemplate.addEventListener('stamping', function onceStamped(){
+                            expect(importedTemplate.model.scope1).to.equal(changedScope);
+                            done();
+                        });
                     });
                 });
 
-                it('should attach new `.Html` property as href attribute and property for `<imported-template>`', function () {
-                    expect(importedTemplate.getAttribute("href")).to.equal('/sc/htmlmerger?scope1=scopeAHtml&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
-                    expect(importedTemplate.href).to.equal('/sc/htmlmerger?scope1=scopeAHtml&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
-                });
-                it('should NOT attach new partial model to `imported-template` immediately', function () {
-                    expect(importedTemplate.model).to.equal(partial);
-                });
-                it('should attach new partial model to `imported-template` on `stamping`', function (done) {
-                    importedTemplate.addEventListener('stamping', function onceStamped(){
-                        expect(importedTemplate.model.scope1).to.equal(changedScope);
-                        done();
-                    });
-                });
-            });
+                describe('after `dom-bind` re-set the sub-partial (just one scope) to the same instance', function () {
+                    var scope;
 
-            describe('after `dom-bind` re-set the sub-partial property (just one scope) to the same instance', function () {
-                var scope;
-
-                beforeEach(function(done) {
-                    // IDEA: promisify juicy-html
-                    sinon.stub(importedTemplate, "_setPendingPropertyOrPath");
-                    importedTemplate.addEventListener('stamping', function onceStamped(){
-                        importedTemplate.removeEventListener('stamping', onceStamped);
+                    beforeEach(function() {
+                        sinon.stub(importedTemplate, "_setPendingPropertyOrPath");
                         scope = domBind.get('model.Page.scope1');
                         domBind.set('model.Page.scope1', scope);
-                        done();
+                    });
+
+                    it('should NOT forward the notification to `imported-template` - Polymer limitation', function () {
+                        expect(importedTemplate._setPendingPropertyOrPath).not.to.be.called;
                     });
                 });
 
-                it('should NOT forward the notification to `imported-template` - Polymer limitation', function () {
-                    expect(importedTemplate._setPendingPropertyOrPath).not.to.be.called;
-                });
-            });
+                describe('after `dom-bind` changes the sub-partial\'s property of a view with an explicit composition', function () {
+                    var scope, include, newVal = "yeah", customComposition = "my custom composition", shadowRoot;
 
-            describe('after `dom-bind` changes the sub-partial property of a view with an explicit composition', function () {
-                var scope, include, newVal = "yeah", customComposition = "my custom composition";
-
-                beforeEach(function(done) {
-                    sinon.stub(importedTemplate, "_setPendingPropertyOrPath");
-                    importedTemplate.addEventListener('stamping', function onceStamped(){
-                        importedTemplate.removeEventListener('stamping', onceStamped);
+                    beforeEach(function() {
+                        sinon.stub(importedTemplate, "_setPendingPropertyOrPath");
                         include = container.querySelector('starcounter-include');
+                        // TODO: do we really want to tangle starcounter-layout-html-editor in the case that should be atomic as well?
                         include._compositionChanged(customComposition); //this is how starcounter-layout-html-editor uses it
+                        shadowRoot = include.shadowRoot;
                         domBind.set('model.Page.scope1.doesItWork', newVal);
-                        done();
+                    });
+
+                    it('should forward the notification to `imported-template`', function () {
+                        expect(importedTemplate._setPendingPropertyOrPath).to.be.calledWith("model.scope1.doesItWork", newVal);
+                    });
+
+                    it('should preserve the explicit composition', function () {
+                        // check the content
+                        expect(include.shadowRoot.innerHTML).to.be.equal(customComposition);
+                        // check if composition was not re-created => flashed
+                        expect(include.shadowRoot).to.equal(shadowRoot);
                     });
                 });
 
-                it('should forward the notification to `imported-template`', function () {
-                    expect(importedTemplate._setPendingPropertyOrPath).to.be.calledWith("model.scope1.doesItWork", newVal);
-                });
-
-                it('should preserve the explicit composition', function () {
-                    expect(include.shadowRoot.innerHTML).to.be.equal(customComposition);
-                });
-            });
-
-            describe('after `dom-bind`` changed the sub-partial property (just one scope) to new one with thethat results with the same merged Html', function () {
-                var changedScopeWithSameHtml;
-                beforeEach(function(done) {
-                    // IDEA: promisify juicy-html
-                    importedTemplate.addEventListener('stamping', function onceStamped(){
-                        importedTemplate.removeEventListener('stamping', onceStamped);
+                describe('after `dom-bind`` changed the sub-partial (just one scope) to new a one that results with the same merged Html', function () {
+                    var changedScopeWithSameHtml;
+                    beforeEach(function() {
+                        sinon.stub(importedTemplate, "_setPendingPropertyOrPath");
                         changedScopeWithSameHtml = {
                             'Html': 'scope1Html',
                             'doesItWork': 'still works!'
                         };
                         domBind.set('model.Page.scope1', changedScopeWithSameHtml);
-                        done();
+                    });
+
+                    it('should keep same `.Html` property as href attribute and propery for `<imported-template>`', function () {
+                        expect(importedTemplate.getAttribute("href")).to.equal('/sc/htmlmerger?scope1=scope1Html&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
+                        expect(importedTemplate.href).to.equal('/sc/htmlmerger?scope1=scope1Html&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
+                    });
+                    it('should attach new partial model to `imported-template` immediately', function () {
+                        expect(importedTemplate.model.scope1).to.equal(changedScopeWithSameHtml);
+                    });
+                    it('should forward the notification to `imported-template` immediately', function () {
+                        expect(importedTemplate._setPendingPropertyOrPath).to.be.calledWith("model.scope1", changedScopeWithSameHtml);
                     });
                 });
 
-                it('should attach same `.Html` property as href attribute and propery for `<imported-template>`', function () {
-                    expect(importedTemplate.getAttribute("href")).to.equal('/sc/htmlmerger?scope1=scope1Html&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
-                    expect(importedTemplate.href).to.equal('/sc/htmlmerger?scope1=scope1Html&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
-                });
-                it('should attach new partial model to `imported-template` immediately', function () {
-                    expect(importedTemplate.model.scope1).to.equal(changedScopeWithSameHtml);
-                });
-            });
+                describe('after `dom-bind`` changed the inner `Html` property', function () {
+                    beforeEach(function() {
+                        sinon.stub(importedTemplate, "_setPendingPropertyOrPath");
+                        domBind.set('model.Page.scope1.Html', 'changedHtml');
+                    });
 
-            describe('after `dom-bind`` changed the inner `Html` property', function () {
-                beforeEach(function() {
-                    domBind.set('model.Page.scope1.Html', 'changedHtml');
-                });
-
-                it('should attach new `.Html` property as href attribute and property for `<imported-template>`', function () {
-                    expect(importedTemplate.getAttribute("href")).to.equal('/sc/htmlmerger?scope1=changedHtml&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
-                    expect(importedTemplate.href).to.equal('/sc/htmlmerger?scope1=changedHtml&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
-                });
-                it('should attach same partial model to `imported-template` on `stamping`', function (done) {
-                    importedTemplate.addEventListener('stamping', function onceStamped(){
-                        expect(importedTemplate.model).to.equal(partial);
-                        done();
+                    it('should attach new `.Html` property as href attribute and property for `<imported-template>`', function () {
+                        expect(importedTemplate.getAttribute("href")).to.equal('/sc/htmlmerger?scope1=changedHtml&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
+                        expect(importedTemplate.href).to.equal('/sc/htmlmerger?scope1=changedHtml&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
+                    });
+                    it('should NOT forward the notification to `imported-template` immediately', function () {
+                        expect(importedTemplate._setPendingPropertyOrPath).not.to.be.called;
+                    });
+                    it('should attach same partial model to `imported-template` on `stamping`', function (done) {
+                        importedTemplate.addEventListener('stamping', function onceStamped(){
+                            expect(importedTemplate.model).to.equal(partial);
+                            done();
+                        });
                     });
                 });
-            });
 
-            describe('after `dom-bind`` removed the inner `Html` property', function () {
-                beforeEach(function(done) {
-                    importedTemplate.addEventListener('stamping', function onceStamped(){
-                        importedTemplate.removeEventListener('stamping', onceStamped);
+                describe('after `dom-bind`` removed the inner `Html` property', function () {
+                    beforeEach(function() {
                         // not realy removing, but Polymer does not support anything better
                         // https://github.com/Polymer/polymer/issues/2565
                         domBind.set('model.Page.Html', null);
                         // domBind.set('model.Page.Html', undefined);
-                        done();
                     });
-                });
 
-                it('should attach `null` as href attribute and property for `<imported-template>`', function () {
-                    expect(importedTemplate.getAttribute("href")).to.equal(null);
-                    expect(importedTemplate.href).to.equal(null);
-                });
-                it('should attach same partial model to `imported-template`', function () {
-                    expect(importedTemplate.model).to.equal(partial);
+                    it('should attach `null` as href attribute and property for `<imported-template>`', function () {
+                        expect(importedTemplate.getAttribute("href")).to.equal(null);
+                        expect(importedTemplate.href).to.equal(null);
+                    });
+                    it('should attach same partial model to `imported-template`', function () {
+                        expect(importedTemplate.model).to.equal(partial);
+                    });
                 });
             });
         });

--- a/test/v1/basic.html
+++ b/test/v1/basic.html
@@ -7,7 +7,6 @@
     <title>starcounter-include composition basic test</title>
     <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../../web-component-tester/browser.js"></script>
-    <script src="../helpers/pre-config.js"></script>
     <link rel="import" href="../../../polymer/polymer.html">
 
     <link rel="import" href="../../starcounter-include.html">


### PR DESCRIPTION
Fix the flow, do try to stamp partial on constructor,

do it on `connectedCallback` and partial set,

Allow changing sub-partial's Html property or entire sub-partial via Polymer
Set href in `stampImportedTemplate`, do not set the model in partial setter if the template is already being stamped

Simplify model setting
Rename _compositionChanged to updateComposition

Problems:
 There was a blank page sometimes - #71
 There was a bunch of failing tests - #71, #69,
 The flow was missing many cases. #75 

Includes https://github.com/Starcounter/starcounter-include/pull/77

PS. The remaining 7 tests that are failing are due to the quirk of Shadow DOM polyfill (applies scoped ShadyCSS styles asynchronously), that does not seem to affect our use cases at least in a visible manner. Allowing app devs to continue development in all major browsers. Requires further investigation.