### PR TITLE
Unhardcode CompositionProvider (fix #79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,16 +135,17 @@ Attribute     | Options  | Default      | Description
 Property   | Options           | Default | Description
 ---         | ---               | ---     | ---
 `partial`   | *Object*          |         | Object containing partial view-model, bindable with Polymer
-`partialId` | *String*          |         | Partial Id used to identify partial, usually it's fetched from `partial.CompositionProvider.PartialId`.
+`partialId` | *String*          |         | Partial Id used to identify partial, usually it's fetched from `partial.{CompositionProvider}.PartialId`.
 `viewModel` | *Object*          |         | Alias for `partial`
+`CompositionProvider` | *String* | `CompositionProvider_0` | Key/app name of composition provider. could be overwritten per instance `scInclude.CompositionProvider` or globally by changing the prototype, like: `customElements.get('starcounter-include').prototype.CompositionProvider = 'CustomProvider_7'`
 
 ## Events
 
 Name                                    | Detail                 | Description
 ---                                     | ---                    | ---
 `starcounter-include-composition-saved` | *String* stored layout | Triggered once composition is saved
-`partial-changed`                       | *Object* `{value: storedLayout, path: 'partial.CompositionProvider.Composition$'}` | Polymer notification protocol compilant event to notify about `partial.CompositionProvider.Composition$` change, triggered once composition is saved.
-`view-model-changed`                       | *Object* `{value: storedLayout, path: 'viewModel.CompositionProvider.Composition$'}` | Polymer notification protocol compilant event to notify about `partial.CompositionProvider.Composition$` change, triggered once composition is saved.
+`partial-changed`                       | *Object* `{value: storedLayout, path: 'partial.{CompositionProvider}.Composition$'}` | Polymer notification protocol compilant event to notify about `partial.{CompositionProvider}.Composition$` change, triggered once composition is saved.
+`view-model-changed`                       | *Object* `{value: storedLayout, path: 'viewModel.{CompositionProvider}.Composition$'}` | Polymer notification protocol compilant event to notify about `partial.{CompositionProvider}.Composition$` change, triggered once composition is saved.
 
 ## Test suite
 

--- a/README.md
+++ b/README.md
@@ -135,17 +135,17 @@ Attribute     | Options  | Default      | Description
 Property   | Options           | Default | Description
 ---         | ---               | ---     | ---
 `partial`   | *Object*          |         | Object containing partial view-model, bindable with Polymer
-`partialId` | *String*          |         | Partial Id used to identify partial, usually it's fetched from `partial.{CompositionProvider}.PartialId`.
+`partialId` | *String*          |         | Partial Id used to identify partial, usually it's fetched from `partial.{compositionProvider}.PartialId`.
 `viewModel` | *Object*          |         | Alias for `partial`
-`CompositionProvider` | *String* | `CompositionProvider_0` | Key/app name of composition provider. could be overwritten per instance `scInclude.CompositionProvider` or globally by changing the prototype, like: `customElements.get('starcounter-include').prototype.CompositionProvider = 'CustomProvider_7'`
+`compositionProvider` | *String* | `CompositionProvider_0` | Key/app name of composition provider. could be overwritten per instance `scInclude.compositionProvider` or globally by changing the prototype, like: `customElements.get('starcounter-include').prototype.compositionProvider = 'CustomProvider_7'`
 
 ## Events
 
 Name                                    | Detail                 | Description
 ---                                     | ---                    | ---
 `starcounter-include-composition-saved` | *String* stored layout | Triggered once composition is saved
-`partial-changed`                       | *Object* `{value: storedLayout, path: 'partial.{CompositionProvider}.Composition$'}` | Polymer notification protocol compilant event to notify about `partial.{CompositionProvider}.Composition$` change, triggered once composition is saved.
-`view-model-changed`                       | *Object* `{value: storedLayout, path: 'viewModel.{CompositionProvider}.Composition$'}` | Polymer notification protocol compilant event to notify about `partial.{CompositionProvider}.Composition$` change, triggered once composition is saved.
+`partial-changed`                       | *Object* `{value: storedLayout, path: 'partial.{compositionProvider}.Composition$'}` | Polymer notification protocol compliant event to notify about `partial.{compositionProvider}.Composition$` change, triggered once composition is saved.
+`view-model-changed`                       | *Object* `{value: storedLayout, path: 'viewModel.{compositionProvider}.Composition$'}` | Polymer notification protocol compliant event to notify about `partial.{compositionProvider}.Composition$` change, triggered once composition is saved.
 
 ## Test suite
 

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -3,7 +3,7 @@
 Custom Element (w/ Polymer's TemplateBinding)
 with predefined template content, which should be used to include partials.
 It's just <imported-template> wrapped within Shadow Root for `declarative-shadow-dom` bindable by layout editor.
-Uses Shadow DOM given from DB as `Starcounter.MergedPartial.{_CompositionProvider_}.Composition$`.
+Uses Shadow DOM given from DB as `Starcounter.MergedPartial.{_compositionProvider_}.Composition$`.
 version: 4.1.0
 
 -->
@@ -231,11 +231,11 @@ version: 4.1.0
             }
         }
         /**
-         * @deprecated Use `starcounterInclude.shadowRoot` or `viewModel.{CompositionProvider}.Composition$`
+         * @deprecated Use `starcounterInclude.shadowRoot` or `viewModel.{compositionProvider}.Composition$`
          * @alias #updateComposition
          */
         StarcounterIncludePrototype._compositionChanged = function(compositionString) {
-            console.warn('_compositionChanged, was renamed to updateComposition. Most probably you don\'t even need to use it. In most of the cases `starcounterInclude.shadowRoot` or changing the `viewModel.{CompositionProvider}.Composition$` should do the right thing.');
+            console.warn('_compositionChanged, was renamed to updateComposition. Most probably you don\'t even need to use it. In most of the cases `starcounterInclude.shadowRoot` or changing the `viewModel.{compositionProvider}.Composition$` should do the right thing.');
             return this.updateComposition(compositionString);
         };
         /**
@@ -253,7 +253,7 @@ version: 4.1.0
                 return this._renderCompositionChange(compositionString, () => this.stringToDocumentFragment(compositionString));
             }
             else {
-                const compositionProvider = this.partial && this.partial[this.CompositionProvider];
+                const compositionProvider = this.partial && this.partial[this.compositionProvider];
 
                 if (compositionProvider) {
                     this.partialId = compositionProvider.PartialId;
@@ -340,7 +340,7 @@ version: 4.1.0
                             this.template._setPendingPropertyOrPath(newPath, value);
                         }
                         // There is no chance that composition changed by changing just Apps model
-                        // TODO: unless it's Composition Provider add a test for a change for just model.CompositionProvider_0
+                        // TODO: unless it's Composition Provider add a test for a change for just model.{compositionProvider}
                     }
                     return ;
                 }
@@ -353,7 +353,7 @@ version: 4.1.0
                     this._updateHref();
                     return;
                 }
-                // TODO: handle just composition change add a test for a change for just model.CompositionProvider_0.Composition$
+                // TODO: handle just composition change add a test for a change for just model.{compositionProvider}.Composition$
                 // Notify about model change
                 if (this.template._setPendingPropertyOrPath) {
                     this.template._setPendingPropertyOrPath(newPath, value);
@@ -415,10 +415,10 @@ version: 4.1.0
          */
         StarcounterIncludePrototype.saveLayout = function(compositionStr){
             compositionStr = compositionStr || this.shadowRoot.innerHTML;
-            this.partial[this.CompositionProvider].Composition$ = compositionStr;
+            this.partial[this.compositionProvider].Composition$ = compositionStr;
             this.dispatchEvent(new CustomEvent("starcounter-include-composition-saved", {detail: compositionStr}));
             // trigger polymer-notification-protocol-compilant event
-            var notificationPath = this.CompositionProvider + '.Composition$';
+            var notificationPath = this.compositionProvider + '.Composition$';
             this.dispatchEvent(new CustomEvent("partial-changed", {detail: {value: compositionStr, path: 'partial.' + notificationPath}}));
             this.dispatchEvent(new CustomEvent("view-model-changed", {detail: {value: compositionStr, path: 'viewModel.' + notificationPath}}));
         };
@@ -444,7 +444,7 @@ version: 4.1.0
          * Could be overwritten per instance or globally if you change the prototype.
          * @type {String}
          */
-        StarcounterIncludePrototype.CompositionProvider = 'CompositionProvider_0';
+        StarcounterIncludePrototype.compositionProvider = 'CompositionProvider_0';
 
         /**
          * Check if given viewModel is non-namespace (contains `.Html` property)

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -3,7 +3,7 @@
 Custom Element (w/ Polymer's TemplateBinding)
 with predefined template content, which should be used to include partials.
 It's just <imported-template> wrapped within Shadow Root for `declarative-shadow-dom` bindable by layout editor.
-Uses Shadow DOM given from DB as `Starcounter.MergedPartial.(CompositionProvider|CompositionProvider_0).Composition$`.
+Uses Shadow DOM given from DB as `Starcounter.MergedPartial.{_CompositionProvider_}.Composition$`.
 version: 4.1.0
 
 -->
@@ -253,7 +253,7 @@ version: 4.1.0
                 return this._renderCompositionChange(compositionString, () => this.stringToDocumentFragment(compositionString));
             }
             else {
-                const compositionProvider = this.partial && findCompositionProvider(this.partial);
+                const compositionProvider = this.partial && this.partial[this.CompositionProvider];
 
                 if (compositionProvider) {
                     this.partialId = compositionProvider.PartialId;
@@ -415,10 +415,10 @@ version: 4.1.0
          */
         StarcounterIncludePrototype.saveLayout = function(compositionStr){
             compositionStr = compositionStr || this.shadowRoot.innerHTML;
-            findCompositionProvider(this.partial).Composition$ = compositionStr;
+            this.partial[this.CompositionProvider].Composition$ = compositionStr;
             this.dispatchEvent(new CustomEvent("starcounter-include-composition-saved", {detail: compositionStr}));
             // trigger polymer-notification-protocol-compilant event
-            var notificationPath = findCompositionProviderPath(this.partial) + '.Composition$';
+            var notificationPath = this.CompositionProvider + '.Composition$';
             this.dispatchEvent(new CustomEvent("partial-changed", {detail: {value: compositionStr, path: 'partial.' + notificationPath}}));
             this.dispatchEvent(new CustomEvent("view-model-changed", {detail: {value: compositionStr, path: 'viewModel.' + notificationPath}}));
         };
@@ -438,23 +438,13 @@ version: 4.1.0
             }
             return range.createContextualFragment(htmlStr);
         }
-
         /**
-         * Find composition provider scope in given marged/namespaced view-model
-         * @param  {Object} obj namespaced view-model
-         * @return {Object}     Composition Provider scope
+         * Composition provider key.
+         * The place which the element will check for compositions.
+         * Could be overwritten per instance or globally if you change the prototype.
+         * @type {String}
          */
-        function findCompositionProvider(obj) {
-            return obj.CompositionProvider || obj.CompositionProvider_0;
-        };
-        /**
-         * Find composition provider path in given marged/namespaced view-model
-         * @param  {Object} obj namespaced view-model
-         * @return {String}     path to Composition Provider scope
-         */
-        function findCompositionProviderPath(obj) {
-            return obj.CompositionProvider && 'CompositionProvider'|| obj.CompositionProvider_0 && 'CompositionProvider_0';
-        };
+        StarcounterIncludePrototype.CompositionProvider = 'CompositionProvider_0';
 
         /**
          * Check if given viewModel is non-namespace (contains `.Html` property)

--- a/test/composition/custom.html
+++ b/test/composition/custom.html
@@ -21,7 +21,7 @@
     <test-fixture id="initial-fixture">
         <template>
             <starcounter-include partial="{
-                &quot;CompositionProvider&quot;: {
+                &quot;CompositionProvider_0&quot;: {
                     &quot;PartialId&quot;: &quot;given PartialId&quot;,
                     &quot;Composition$&quot;: &quot;customComposition!<slot></slot>&quot;
                 },
@@ -73,7 +73,7 @@
                 var composition$;
                 var explicitComposition = "explicit composition";
                 beforeEach(function () {
-                    composition$ = scInclude.viewModel.CompositionProvider.Composition$;
+                    composition$ = scInclude.viewModel.CompositionProvider_0.Composition$;
                     scInclude.updateComposition(explicitComposition);
                 });
                 it('should render the explicit composition', function () {
@@ -85,7 +85,7 @@
                     expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString(REFERENCE_DEFAULT);
                 });
                 it('should NOT overwrite Composition$', function () {
-                    expect(scInclude.viewModel.CompositionProvider.Composition$).to.be.equal(composition$);
+                    expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.equal(composition$);
                 });
                 describe('after saveLayout() is called', function () {
                     beforeEach(function () {
@@ -93,7 +93,7 @@
                         scInclude.updateComposition(); //simulate notifyPath which can trigger updateComposition
                     });
                     it('should overwrite Composition$', function () {
-                        expect(scInclude.viewModel.CompositionProvider.Composition$.trim()).to.be.equal(explicitComposition);
+                        expect(scInclude.viewModel.CompositionProvider_0.Composition$.trim()).to.be.equal(explicitComposition);
                     });
                     it('should render the explicit composition', function () {
                         expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(explicitComposition);

--- a/test/composition/default-declarative-shadow-dom.html
+++ b/test/composition/default-declarative-shadow-dom.html
@@ -22,7 +22,7 @@
     <test-fixture id="default-composition">
         <template>
             <starcounter-include partial="{
-                &quot;CompositionProvider&quot;: {
+                &quot;CompositionProvider_0&quot;: {
                     &quot;PartialId&quot;: &quot;given PartialId&quot;,
                     &quot;Composition$&quot;: &quot;&quot;
                 },
@@ -55,7 +55,7 @@
 
         var scInclude;
         var alternativePartial = {
-            "CompositionProvider": {
+            "CompositionProvider_0": {
                 "PartialId": "given PartialId",
                 "Composition$": "",
                 "ViewUris": []
@@ -66,7 +66,7 @@
             }
         };
         var alternativePartialWithTwo = {
-            "CompositionProvider": {
+            "CompositionProvider_0": {
                 "PartialId": "given PartialId",
                 "Composition$": "custom!",
                 "ViewUris": ["template_w_declarative-shadow-dom.html"]
@@ -110,7 +110,7 @@
             var composition$;
             var explicitComposition = "explicit composition";
             beforeEach(function() {
-                composition$ = scInclude.viewModel.CompositionProvider.Composition$;
+                composition$ = scInclude.viewModel.CompositionProvider_0.Composition$;
                 scInclude.updateComposition(explicitComposition);
             });
             it('should render the explicit composition', function() {
@@ -122,7 +122,7 @@
                     .sameHTMLString(REFERENCE_COMPOSITION);
             });
             it('should NOT overwrite Composition$', function() {
-                expect(scInclude.viewModel.CompositionProvider.Composition$).to.be.equal(composition$);
+                expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.equal(composition$);
             });
             describe('after saveLayout() is called', function() {
                 beforeEach(function() {
@@ -130,7 +130,7 @@
                     scInclude.updateComposition(); //simulate notifyPath which can trigger updateComposition
                 });
                 it('should overwrite Composition$', function() {
-                    expect(scInclude.viewModel.CompositionProvider.Composition$.trim()).to.be.equal(explicitComposition);
+                    expect(scInclude.viewModel.CompositionProvider_0.Composition$.trim()).to.be.equal(explicitComposition);
                 });
                 it('should render the explicit composition', function() {
                     expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(explicitComposition);
@@ -151,7 +151,7 @@
                 var composition$;
                 var explicitComposition = "explicit composition";
                 beforeEach(function() {
-                    composition$ = scInclude.viewModel.CompositionProvider.Composition$;
+                    composition$ = scInclude.viewModel.CompositionProvider_0.Composition$;
                     scInclude.updateComposition(explicitComposition);
                 });
                 it('should render the explicit composition', function() {
@@ -163,7 +163,7 @@
                         .sameHTMLString(REFERENCE_COMPOSITION + REFERENCE_ALTERNATIVE_COMPOSITION);
                 });
                 it('should NOT overwrite Composition$', function() {
-                    expect(scInclude.viewModel.CompositionProvider.Composition$).to.be.equal(composition$);
+                    expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.equal(composition$);
                 });
                 describe('after saveLayout() is called', function() {
                     beforeEach(function() {
@@ -171,7 +171,7 @@
                         scInclude.updateComposition(); //simulate notifyPath which can trigger updateComposition
                     });
                     it('should overwrite Composition$', function() {
-                        expect(scInclude.viewModel.CompositionProvider.Composition$.trim()).to.be.equal(explicitComposition);
+                        expect(scInclude.viewModel.CompositionProvider_0.Composition$.trim()).to.be.equal(explicitComposition);
                     });
                     it('should render the explicit composition', function() {
                         expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(explicitComposition);

--- a/test/composition/default-starcounter-composition.html
+++ b/test/composition/default-starcounter-composition.html
@@ -22,7 +22,7 @@
     <test-fixture id="default-composition">
         <template>
             <starcounter-include partial="{
-                &quot;CompositionProvider&quot;: {
+                &quot;CompositionProvider_0&quot;: {
                     &quot;PartialId&quot;: &quot;given PartialId&quot;
                 },
                 &quot;App&quot;: {
@@ -50,7 +50,7 @@
 
         var scInclude;
         var partial = {
-            "CompositionProvider": {
+            "CompositionProvider_0": {
                 "PartialId": "given PartialId"
             },
             "App": {

--- a/test/composition/fallback.html
+++ b/test/composition/fallback.html
@@ -21,7 +21,7 @@
     <test-fixture id="initial-fixture">
         <template>
             <starcounter-include partial="{
-                &quot;CompositionProvider&quot;: {
+                &quot;CompositionProvider_0&quot;: {
                     &quot;PartialId&quot;: &quot;given PartialId&quot;,
                     &quot;Composition$&quot;: &quot;&quot;
                 },
@@ -82,7 +82,7 @@
                 expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(REFERENCE_FALLBACK);
             });
             it('should NOT overwrite Composition$', function() {
-                expect(scInclude.viewModel.CompositionProvider.Composition$).to.be.equal("");
+                expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.equal("");
             });
             describe('after saveLayout() is called', function() {
                 beforeEach(function() {
@@ -90,7 +90,7 @@
                     scInclude.updateComposition(); //simulate notifyPath which can trigger updateComposition
                 });
                 it('should overwrite Composition$', function() {
-                    expect(scInclude.viewModel.CompositionProvider.Composition$.trim()).to.be.equal(explicitComposition);
+                    expect(scInclude.viewModel.CompositionProvider_0.Composition$.trim()).to.be.equal(explicitComposition);
                 });
                 it('should render the explicit composition', function() {
                     expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(explicitComposition);

--- a/test/helpers/composition-fixtures.js
+++ b/test/helpers/composition-fixtures.js
@@ -28,7 +28,7 @@ const REFERENCE_FALLBACK = useShadowDOMV1 ?
 
 function partialWithCustom() {
     return {
-        "CompositionProvider": {
+        "CompositionProvider_0": {
             "PartialId": "given PartialId",
             "Composition$": "customComposition!<slot></slot>"
         },
@@ -41,7 +41,7 @@ function partialWithCustom() {
 
 function partialWithDefault() {
     return {
-        "CompositionProvider": {
+        "CompositionProvider_0": {
             "PartialId": "given PartialId",
             "Composition$": ""
         },
@@ -54,7 +54,7 @@ function partialWithDefault() {
 
 function partialWithFallback() {
     return {
-        "CompositionProvider": {
+        "CompositionProvider_0": {
             "PartialId": "given PartialId",
             "Composition$": ""
         },

--- a/test/partialAttribute/cleanup_removed_partial_Layout.html
+++ b/test/partialAttribute/cleanup_removed_partial_Layout.html
@@ -33,7 +33,7 @@
             var instance;
             var model = {
                 "Html": "../templateToInclude.html",
-                "CompositionProvider": {
+                "CompositionProvider_0": {
                     "Composition$": 'a Composition',
                     "PartialId": "given PartialId"
                 },
@@ -95,7 +95,7 @@
                     expect(instance).to.have.compositionAttached;
                     instance.partial = {
                         "Html": "../templateToInclude.html",
-                        "CompositionProvider": {
+                        "CompositionProvider_0": {
                             "Composition$": "",
                             "PartialId": ""
                         },

--- a/test/partialAttribute/cleanup_removed_partial_PartialId.html
+++ b/test/partialAttribute/cleanup_removed_partial_PartialId.html
@@ -30,7 +30,7 @@
             var instance;
             var model = {
                 "Html": "../templateToInclude.html",
-                "CompositionProvider": {
+                "CompositionProvider_0": {
                     "PartialId": "templateToInclude.html"
                 },
                 "doesItWork": "works!"
@@ -91,7 +91,7 @@
                     expectPartialToBeAttached();
                     instance.partial = {
                         "Html": "../templateToInclude.html",
-                        "CompositionProvider": {
+                        "CompositionProvider_0": {
                             "PartialId": ""
                         },
                         "doesItWork": "works!"
@@ -102,8 +102,8 @@
             });
 
             function expectPartialToBeAttached() {
-                expect(instance).to.have.HTMLAttribute('partial-id').equal(model.CompositionProvider.PartialId);
-                expect(instance.partialId).to.be.equal(model.CompositionProvider.PartialId);
+                expect(instance).to.have.HTMLAttribute('partial-id').equal(model.CompositionProvider_0.PartialId);
+                expect(instance.partialId).to.be.equal(model.CompositionProvider_0.PartialId);
             }
 
             function expectPartialToBeCleanedUp() {

--- a/test/partialId-property/reflect-partialId-to-attribute.html
+++ b/test/partialId-property/reflect-partialId-to-attribute.html
@@ -22,7 +22,7 @@
             <!-- nest to workaround test-fixture bug -->
             <div>
                 <starcounter-include partial="{
-                    &quot;CompositionProvider&quot;: {
+                    &quot;CompositionProvider_0&quot;: {
                         &quot;PartialId&quot;: &quot;given PartialId&quot;
                     },
                     &quot;Html&quot;: &quot;../templateToInclude.html&quot;,
@@ -63,7 +63,7 @@
     <test-fixture id="no-CompositionProvider.PartialId">
         <template>
             <div>
-                <starcounter-include partial="{&quot;Html&quot;: &quot;../old_templateToInclude.html&quot;, &quot;doesItWork&quot;: &quot;worked!&quot;, &quot;CompositionProvider&quot;: {}}"></starcounter-include>
+                <starcounter-include partial="{&quot;Html&quot;: &quot;../old_templateToInclude.html&quot;, &quot;doesItWork&quot;: &quot;worked!&quot;, &quot;CompositionProvider_0&quot;: {}}"></starcounter-include>
             </div>
         </template>
     </test-fixture>
@@ -71,7 +71,7 @@
         <template>
             <div>
                 <starcounter-include partial="{
-                    &quot;CompositionProvider&quot;: {
+                    &quot;CompositionProvider_0&quot;: {
                         &quot;PartialId&quot;: &quot;old PartialId&quot;,
                     },
                     &quot;Html&quot;: &quot;../templateToInclude.html&quot;,
@@ -86,7 +86,7 @@
         var scInclude;
         function getFullPartial() {
           return {
-              "CompositionProvider": {
+              "CompositionProvider_0": {
                   "PartialId": "given PartialId"
               },
               "Html": "../templateToInclude.html",
@@ -95,7 +95,7 @@
         }
         function getNewPartial() {
           return {
-            "CompositionProvider": {
+            "CompositionProvider_0": {
                 "PartialId": "new PartialId"
             },
             "Html": "../templateToInclude.html",
@@ -126,7 +126,7 @@
             expect(scInclude).to.have.HTMLAttribute('partial-id').equal('new PartialId');
         });
 
-        it('when it was set, then changed with Polymer dom-bind (`CompositionProvider` object), should reflect this change', function (done) {
+        it('when it was set, then changed with Polymer dom-bind (`CompositionProvider_0` object), should reflect this change', function (done) {
             var domBind;
             container = fixture('dom-bind');
             domBind = container.querySelector('dom-bind');
@@ -138,7 +138,7 @@
                 expect(scInclude).to.have.HTMLAttribute('partial-id').equal('given PartialId');
 
                 // change .PartialId
-                domBind.set('partial.CompositionProvider', {PartialId: "new PartialId"});
+                domBind.set('partial.CompositionProvider_0', {PartialId: "new PartialId"});
                 setTimeout(function oncePolymerNotificationPropagated() {
                     expect(scInclude.partialId).to.equal('new PartialId');
                     expect(scInclude).to.have.HTMLAttribute('partial-id').equal('new PartialId');
@@ -147,7 +147,7 @@
             }, 100);
         });
 
-        it('when it was set, then changed with Polymer dom-bind (just `CompositionProvider.PartialId` property), should reflect this change', function (done) {
+        it('when it was set, then changed with Polymer dom-bind (just `CompositionProvider_0.PartialId` property), should reflect this change', function (done) {
             var domBind;
             container = fixture('dom-bind');
             domBind = container.querySelector('dom-bind');
@@ -159,7 +159,7 @@
                 expect(scInclude).to.have.HTMLAttribute('partial-id').equal('given PartialId');
 
                 // change .PartialId
-                domBind.set('partial.CompositionProvider.PartialId', 'new PartialId');
+                domBind.set('partial.CompositionProvider_0.PartialId', 'new PartialId');
                 setTimeout(function oncePolymerNotificationPropagated() {
                     expect(scInclude.partialId).to.equal('new PartialId');
                     expect(scInclude).to.have.HTMLAttribute('partial-id').equal('new PartialId');

--- a/test/v0/basic.html
+++ b/test/v0/basic.html
@@ -63,8 +63,8 @@
                 // domBind.addEventListener('dom-change', function waitForDomBind(){
                     scInclude = container.querySelector('starcounter-include');
                     composition = document.querySelector('#composition').innerHTML;
-                    domBind.set('partial', {CompositionProvider:{Composition$: null}});
-                    domBind.set('partial.CompositionProvider.Composition$', composition);
+                    domBind.set('partial', {CompositionProvider_0:{Composition$: null}});
+                    domBind.set('partial.CompositionProvider_0.Composition$', composition);
                     // setTimeout(function waitForPolyfilledUpgrade(){
                         done();
                     // },100);

--- a/test/v0/polyfill-next-selector.html
+++ b/test/v0/polyfill-next-selector.html
@@ -62,7 +62,7 @@ describe('starcounter-include when stamps a composition which contains `polyfill
         }
 		scInclude = fixture('element');
 		scInclude.viewModel = {
-			CompositionProvider:{
+			CompositionProvider_0:{
 				Composition$: document.querySelector('#composition').innerHTML
 			}
 		};

--- a/test/v0/smoke/webcomponents-webcomponentsjs-issues-648.html
+++ b/test/v0/smoke/webcomponents-webcomponentsjs-issues-648.html
@@ -32,7 +32,7 @@
                 scInclude = fixture('element');
                 compositionTemplate = document.querySelector('#composition');
     			scInclude.viewModel = {
-    				CompositionProvider:{
+    				CompositionProvider_0:{
     					Composition$: compositionTemplate.innerHTML
     				}
     			};

--- a/test/v0/translate/v1-to-v0.html
+++ b/test/v0/translate/v1-to-v0.html
@@ -67,7 +67,7 @@
 		beforeEach(function (done) {
 			scInclude = fixture('element');
 			scInclude.viewModel = {
-				CompositionProvider:{
+				CompositionProvider_0:{
 					Composition$: document.querySelector('#composition').innerHTML
 				}
 			};

--- a/test/v1/basic.html
+++ b/test/v1/basic.html
@@ -57,15 +57,15 @@
             });
         });
 
-        describe('when `.CompositionProvider.Composition$` property is set', function () {
+        describe('when `.CompositionProvider_0.Composition$` property is set', function () {
             beforeEach(function (done) {
                 container = fixture('element');
                 domBind = container.querySelector('dom-bind');
                 // domBind.addEventListener('dom-change', function waitForDomBind(){
                     scInclude = container.querySelector('starcounter-include');
                     composition = document.querySelector('#composition').innerHTML;
-                    domBind.set('partial', {CompositionProvider:{Composition$: null}});
-                    domBind.set('partial.CompositionProvider.Composition$', composition);
+                    domBind.set('partial', {CompositionProvider_0:{Composition$: null}});
+                    domBind.set('partial.CompositionProvider_0.Composition$', composition);
                     // setTimeout(function waitForPolyfilledUpgrade(){
                         done();
                     // },100);

--- a/test/v1/smoke/webcomponents-webcomponentsjs-issues-648.html
+++ b/test/v1/smoke/webcomponents-webcomponentsjs-issues-648.html
@@ -33,7 +33,7 @@
                 scInclude = fixture('element');
                 compositionTemplate = document.querySelector(isShadyDOMinUse ? '#composition-polyfilled' : '#composition');
     			scInclude.viewModel = {
-    				CompositionProvider:{
+    				CompositionProvider_0:{
     					Composition$: compositionTemplate.innerHTML
     				}
     			};

--- a/test/v1/translate/v0-to-v1.html
+++ b/test/v1/translate/v0-to-v1.html
@@ -91,7 +91,7 @@
 		beforeEach(function (done) {
 			scInclude = fixture('element');
 			scInclude.viewModel = {
-				CompositionProvider:{
+				CompositionProvider_0:{
 					Composition$: document.querySelector('#composition').innerHTML
 				}
 			};


### PR DESCRIPTION
It could be configured per instance as well as globally by updating the prototype.

remaining: update tests, add new one

Related issues:
https://github.com/Starcounter/starcounter-include/issues/30
https://github.com/Starcounter/starcounter-include/issues/43
https://github.com/Starcounter/starcounter-include/issues/79