### PR TITLE
Hide host while external stylesheets are being loaded

### DIFF
--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -467,6 +467,25 @@ Please make sure it's a result of \`Self.GET\` on serverside. If it's not a resu
             if (givenComposition !== undefined) {
                 // reset SD to default CSS
                 shadowRoot.innerHTML = '';
+                
+                const links = givenComposition.querySelectorAll("link[rel=stylesheet]");
+                let remainingLinks = links.length;
+
+                var linkLoaded = () => {
+                    remainingLinks--;
+                    if(remainingLinks == 0) {
+                        this.style.visibility = "visible";
+                    }
+                };
+
+                if (remainingLinks > 0) {
+                    //workaround for FOUC https://github.com/Starcounter/starcounter-include/issues/93
+                    this.style.visibility = "hidden";
+                    links.forEach(link => {
+                        link.addEventListener("load", linkLoaded); //200 OK
+                        link.addEventListener("error", linkLoaded); //404 Not Found
+                    });
+                }
 
                 shadowRoot.appendChild(givenComposition);
                 // polyfill `polyfill-next-selector` if needed


### PR DESCRIPTION
This change removes FOUC that is explained in #93 but hides the whole starcounter-include for the time of loading stylesheets. This is not optimal but better than FOUC.

Before:

![bug](https://user-images.githubusercontent.com/566463/37156433-5fadfb4a-22e6-11e8-893c-5553e246fbb9.gif)

After:

![bug2](https://user-images.githubusercontent.com/566463/37156427-5c333840-22e6-11e8-9805-a6026ebaea6a.gif)
