### PR TITLE
Add package-log.json to gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,10 +28,10 @@ module.exports = function(grunt) {
 
         bump: {
           options: {
-            files: ['package.json', 'starcounter-include.html'],
+            files: ['package.json', 'package-lock.json', 'starcounter-include.html'],
             commit: true,
             commitMessage: '%VERSION%',
-            commitFiles: ['package.json', 'starcounter-include.html'],
+            commitFiles: ['package.json', 'package-lock.json', 'starcounter-include.html'],
             createTag: true,
             tagName: '%VERSION%',
             tagMessage: 'Version %VERSION%',

--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,7 @@
     "bower_components",
     "Gruntfile.js",
     "wwwroot/sys",
+    "package-lock.json",
     "test",
     "wct.conf.json",
     "demo",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "starcounter-include",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starcounter-include",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Custom Element to include HTML partials/templates from Starcounter",
   "main": "starcounter-include.html",
   "directories": {

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -4,7 +4,7 @@ Custom Element (w/ Polymer's TemplateBinding)
 with predefined template content, which should be used to include partials.
 It's just <imported-template> wrapped within Shadow Root for `declarative-shadow-dom` bindable by layout editor.
 Uses Shadow DOM given from DB as `Starcounter.MergedPartial.{_compositionProvider_}.Composition$`.
-version: 5.1.0
+version: 5.1.1
 
 -->
 <!-- Import dependencies -->


### PR DESCRIPTION
This is to fix this https://github.com/Starcounter/starcounter-include/blob/5.1.0/package-lock.json#L3. See the tag is 5.1.0 but package-lock.json isn't synced.

I realize `package-lock.json` shouldn't be modified manually but it's the simplest solution I could come up with. Grunt bump does not have a `postscript` feature or any of that.

And if I add an NPM script `bump: grunt:bump && npm install` to update package-lock.json, we'd need three `minor`, `major` and `patch` and it's uselss since by the time `&& npm install` is executed, grunt will had been already committed.