### PR TITLE
WIP: Hide the host until all Light or Shadow DOM blocking links are loaded,

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
     "sc"
   ],
   "dependencies": {
-    "imported-template": "^3.1.0"
+    "imported-template": "^3.3.0"
   },
   "devDependencies": {
     "web-component-tester": "^6.0.0",

--- a/bower.json
+++ b/bower.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "web-component-tester": "^6.0.0",
-    "polymer": "^2.2.0"
+    "polymer": "^2.2.0",
+    "enlighted-link": "^0.1.0"
   }
 }

--- a/sc/blocking-links/import.html
+++ b/sc/blocking-links/import.html
@@ -1,0 +1,1 @@
+Something

--- a/sc/blocking-links/styles.css
+++ b/sc/blocking-links/styles.css
@@ -1,0 +1,4 @@
+.green{
+    background: green;
+    color: white;
+}

--- a/sc/blocking-links/template_w_import-async_in_light-dom.html
+++ b/sc/blocking-links/template_w_import-async_in_light-dom.html
@@ -1,0 +1,9 @@
+<template>
+    <link async rel="import" href="/components/starcounter-include/sc/blocking-links/import.html">
+    <h1 slot="my-slot" class="green">Template included</h1>
+    <template is="declarative-shadow-dom">
+        <h2>Default Shadow DOM presentation</h2>
+        <slot name="my-slot"></slot>
+        <slot></slot>
+    </template>
+</template>

--- a/sc/blocking-links/template_w_import_in_light-dom.html
+++ b/sc/blocking-links/template_w_import_in_light-dom.html
@@ -1,0 +1,9 @@
+<template>
+    <link rel="import" href="/components/starcounter-include/sc/blocking-links/import.html">
+    <h1 slot="my-slot" class="green">Template included</h1>
+    <template is="declarative-shadow-dom">
+        <h2>Default Shadow DOM presentation</h2>
+        <slot name="my-slot"></slot>
+        <slot></slot>
+    </template>
+</template>

--- a/sc/blocking-links/template_w_stylesheet-async_in_light-dom.html
+++ b/sc/blocking-links/template_w_stylesheet-async_in_light-dom.html
@@ -1,0 +1,9 @@
+<template>
+    <link async rel="stylesheet" href="/components/starcounter-include/sc/blocking-links/styles.css">
+    <h1 slot="my-slot">Template included</h1>
+    <template is="declarative-shadow-dom">
+        <h2>Default Shadow DOM presentation</h2>
+        <slot name="my-slot"></slot>
+        <slot></slot>
+    </template>
+</template>

--- a/sc/blocking-links/template_w_stylesheet_in_light-dom.html
+++ b/sc/blocking-links/template_w_stylesheet_in_light-dom.html
@@ -1,0 +1,9 @@
+<template>
+    <link rel="stylesheet" href="/components/starcounter-include/sc/blocking-links/styles.css">
+    <h1 slot="my-slot" class="green">Template included</h1>
+    <template is="declarative-shadow-dom">
+        <h2>Default Shadow DOM presentation</h2>
+        <slot name="my-slot"></slot>
+        <slot></slot>
+    </template>
+</template>

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -15,7 +15,7 @@ version: 5.1.0
         function warnAboutDeprecatedPartial() {
             console.warn('`partial` attribute and property are deprecated from `starcounter-include` in favour of (viewModel property or view-model attribute), they will soon be no longer be supported');
         }
-        const BLOCKING_LINKS_SELECTOR = 'link[rel="stylesheet"i]:not([async]),link[rel="import"i]:not([async]),enlighted-link:not([async])';
+        const BLOCKING_LINKS_SELECTOR = 'link[rel="stylesheet"]:not([async]),link[rel="import"]:not([async]),enlighted-link:not([async])';
 
         const isWebkit = navigator.vendor && navigator.vendor.indexOf("Apple") > -1;
 

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -15,15 +15,43 @@ version: 5.1.0
         function warnAboutDeprecatedPartial() {
             console.warn('`partial` attribute and property are deprecated from `starcounter-include` in favour of (viewModel property or view-model attribute), they will soon be no longer be supported');
         }
+        const BLOCKING_LINKS_SELECTOR = 'link[rel="stylesheet"i]:not([async]),link[rel="import"i]:not([async]),enlighted-link:not([async])';
+
         const isWebkit = navigator.vendor && navigator.vendor.indexOf("Apple") > -1;
 
         // still needed for .selectNode
         const isSafari = isWebkit && navigator.userAgent && !navigator.userAgent.match("CriOS");
         const fallBackComposition = '<style>:host{display:block;}</style><slot></slot>';
 
+        /**
+         * Returns a rejectable promise to load (or fail to load) all blocking
+         * link elements in given scope.
+         * @param  {Node} scope scope to be queried for the elements
+         * @return {Promise|null} `.reject()`able promise that all links will be loaded,
+         *                        or `null` if there are none
+         */
+        function blockingLinksLoaded(scope){
+            const links = scope.querySelectorAll(BLOCKING_LINKS_SELECTOR);
+            if(links.length === 0){
+                return null;
+            }
+            let rejectDefer;
+            const promise = new Promise((resolveAll, rejectAll) => {
+                Promise.all(Array.from(links).map((link)=>{
+                    return new Promise((resolve, reject)=>{
+                        link.addEventListener('load', resolve);
+                        link.addEventListener('error', resolve);
+                    });
+                })).then(resolveAll);
+                rejectDefer = rejectAll;
+            });
+            promise.reject = rejectDefer;
+            return promise;
+        }
+
         class StarcounterInclude extends HTMLElement {
             static get observedAttributes() {
-                return ['partial', 'view-model', 'partialId'];
+                return ['partial', 'view-model', 'partialId', 'loading-presentation', 'loading-content'];
             }
             /**
             * Create shadowRoot, define property setters, set initial partial.
@@ -106,9 +134,15 @@ version: 5.1.0
                     const starcounterInclude = this;
                     this.defaultComposition = null;
                     const importedTemplate = document.createElement('imported-template');
+                    // on importing
+                    importedTemplate.addEventListener('stamped', ()=>{
+                        this.setAttribute('loading-content','');
+                        this.blockingLightLinksLoaded && this.blockingLightLinksLoaded.reject();
+                    });
                     importedTemplate.addEventListener('stamping', function fetchCompositions(event) {
                         var mergedComposition = null;
-                        const templates = event.detail.querySelectorAll('template[is="declarative-shadow-dom"][presentation=default],template[is="declarative-shadow-dom"]:not([presentation])');
+                        const fragment = event.detail;
+                        const templates = fragment.querySelectorAll('template[is="declarative-shadow-dom"][presentation=default],template[is="declarative-shadow-dom"]:not([presentation])');
                         if(templates.length){
                             mergedComposition = document.createDocumentFragment();
                             for(const individualComposition of templates) {
@@ -117,6 +151,17 @@ version: 5.1.0
                             };
                         }
                         starcounterInclude.defaultComposition = mergedComposition;
+                        // wait for blocking (not `[async]`) links
+                        const blockingLightLinksLoaded = blockingLinksLoaded(fragment);
+                        this.blockingLightLinksLoaded = blockingLightLinksLoaded;
+                        if(blockingLightLinksLoaded){
+                            blockingLightLinksLoaded.then(()=>{
+                                starcounterInclude.removeAttribute('loading-content');
+                            });
+                        } else {
+                            starcounterInclude.removeAttribute('loading-content');
+                        }
+
 
                         if (this.model !== starcounterInclude.viewModel) {
                             // update entire model
@@ -163,14 +208,25 @@ version: 5.1.0
          * Set partial property if partial or view-model attribute was changed
          */
         StarcounterIncludePrototype.attributeChangedCallback = function(name, oldVal, newVal) {
-            if (name === "view-model") {
-                this.viewModel = partialAttributeToProperty(this, newVal);
-            }
-            else if(name === "partial") {
-                if(!oldVal /* to warn only once */) {
-                    warnAboutDeprecatedPartial();
-                }
-                this.viewModel = partialAttributeToProperty(this, newVal);
+            switch(name){
+                case "view-model":
+                    this.viewModel = partialAttributeToProperty(this, newVal);
+                    break;
+                case "partial":
+                    if(!oldVal /* to warn only once */) {
+                        warnAboutDeprecatedPartial();
+                    }
+                    this.viewModel = partialAttributeToProperty(this, newVal);
+                    break;
+                // Not to overwrite existing compositions, change BlendingEditor,
+                // partialToStandaloneHTMLProvider, and due to lack of
+                // custom-elements default styles
+                // https://github.com/w3c/webcomponents/issues/468
+                // , we need to make single rule inline
+                case "loading-presentation":
+                case "loading-content":
+                    this.style.visibility = (this.hasAttribute('loading-presentation') || this.hasAttribute('loading-content')) ?
+                        'hidden' : 'visible';
             }
         };
         /**
@@ -476,13 +532,25 @@ Please make sure it's a result of \`Self.GET\` on serverside. If it's not a resu
          * @param {DocumentFragment} givenComposition
          */
         StarcounterIncludePrototype.stampComposition = function(givenComposition){
-            // create shadowRoot if none
             const shadowRoot = this.shadowRoot;
+            this.blockingShadowLinksLoaded && this.blockingShadowLinksLoaded.reject();
 
             if (givenComposition !== undefined) {
+                this.setAttribute('loading-presentation', '');
                 // reset SD to default CSS
                 shadowRoot.innerHTML = '';
 
+                // wait for blocking (not `[async]`) links
+                const blockingShadowLinksLoaded = blockingLinksLoaded(givenComposition);
+                this.blockingShadowLinksLoaded = blockingShadowLinksLoaded;
+
+                if(blockingShadowLinksLoaded){
+                    blockingShadowLinksLoaded.then(()=>{
+                        this.removeAttribute('loading-presentation');
+                    });
+                } else {
+                    this.removeAttribute('loading-presentation');
+                }
                 shadowRoot.appendChild(givenComposition);
                 // polyfill `polyfill-next-selector` if needed
                 typeof WebComponents !== 'undefined' && WebComponents.ShadowCSS &&
@@ -500,6 +568,19 @@ Please make sure it's a result of \`Self.GET\` on serverside. If it's not a resu
             console.error('clear is not yet defined!');
         }
 
+        // Desired use of upcomming Web Platform feature,
+        // so we would not have to implement all `loading-*` attributes and
+        // fallback composition logic.
+        // customElements.define('starcounter-include', StarcounterInclude,
+        //         { style: new CSSStyleSheet(`
+        //             :element([loading-content]),
+        //             :element([loading-presentation]){
+        //                 visibility:hidden !important;
+        //             }
+        //             :element{
+        //                 display:block;
+        //             }`)}
+        // );
         customElements.define('starcounter-include', StarcounterInclude);
     })();
 </script>

--- a/test/blocking-links/light-dom.html
+++ b/test/blocking-links/light-dom.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+
+    <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../../web-component-tester/browser.js"></script>
+    <script src="../helpers/chainable-methods-for-partial.js"></script>
+
+    <link rel="import" href="../../../polymer/polymer.html">
+
+    <!-- Step 1: import the element to test -->
+    <link rel="import" href="../../starcounter-include.html">
+    <script src="../helpers/WCT-Polyfill_bugs_workaround.js"></script>
+</head>
+
+<body>
+
+    <div id="testFixtureConatiner"></div>
+
+    <script>
+        var scInclude, importedTemplate;
+        describe(`once imported-template loaded the view, with content that contains a \`link[rel="stylesheet"]\` element without \`async\` attribute`, function () {
+            beforeEach(function (done) {
+                // randomize appname to make every request unique => to have some time to load it
+                const randomAppname = Math.random();
+
+                scInclude = document.createElement('starcounter-include');
+                testFixtureConatiner.appendChild(scInclude);
+                importedTemplate = scInclude.querySelector_template_for_buggy_polyfill();
+                importedTemplate.addEventListener('stamped', ()=>{
+                    console.log('done')
+                    done()
+                });
+                scInclude.viewModel = {
+                    [randomAppname]: {
+                        Html: `blocking-links/template_w_stylesheet_in_light-dom.html`,
+                        doesItWork: "worked!"
+                    }
+                };
+            });
+            afterEach(()=>{
+                testFixtureConatiner.innerHTML = '';
+            });
+
+            it('should set `loading-content` attribute on itself', function () {
+                expect(scInclude).to.have.HTMLAttribute('loading-content').equal("");
+            });
+            it('should have `visibility` style set to `hidden`', function () {
+                expect(scInclude.style).to.have.property('visibility').equal('hidden');
+            });
+            describe('after content is stamped, but before imports are loaded', ()=>{
+                beforeEach(function (done) {
+                    importedTemplate.addEventListener('stamping', ()=>{
+                        console.log('done2')
+                        done();
+                    });
+                });
+                it('should still have `loading-content` attribute on itself', function () {
+                    expect(scInclude).to.have.HTMLAttribute('loading-content').equal("");
+                });
+                it('should still have `visibility` style set to `hidden`', function () {
+                    expect(scInclude.style).to.have.property('visibility').equal('hidden');
+                });
+            });
+            describe('after content is stamped, and all imports are loaded', ()=>{
+                beforeEach(function (done) {
+                    importedTemplate.addEventListener('stamping', ()=>{
+                        setTimeout(done, 1000);
+                    });
+                });
+                it('should no longer have `loading-content` attribute on itself', function () {
+                    expect(scInclude).to.have.HTMLAttribute('loading-content').equal(null);
+                });
+                it('should have `visibility` style set to `visible`', function () {
+                    expect(scInclude.style).to.have.property('visibility').equal('visible');
+                });
+            });
+        });
+        describe(`once imported-template loaded the view, with content that contains a \`link[rel="stylesheet"]\` element with \`async\` attribute`, function () {
+            beforeEach(function (done) {
+                // randomize appname to make every request unique => to have some time to load it
+                const randomAppname = Math.random();
+
+                scInclude = document.createElement('starcounter-include');
+                testFixtureConatiner.appendChild(scInclude);
+                importedTemplate = scInclude.querySelector_template_for_buggy_polyfill();
+                importedTemplate.addEventListener('stamped', ()=>{
+                    console.log('done')
+                    done()
+                });
+                scInclude.viewModel = {
+                    [randomAppname]: {
+                        Html: `blocking-links/template_w_stylesheet-async_in_light-dom.html`,
+                        doesItWork: "worked!"
+                    }
+                };
+            });
+            afterEach(()=>{
+                testFixtureConatiner.innerHTML = '';
+            });
+
+            it('should set `loading-content` attribute on itself', function () {
+                expect(scInclude).to.have.HTMLAttribute('loading-content').equal("");
+            });
+            it('should have `visibility` style set to `hidden`', function () {
+                expect(scInclude.style).to.have.property('visibility').equal('hidden');
+            });
+            describe('after content is stamped, but before imports are loaded', ()=>{
+                beforeEach(function (done) {
+                    importedTemplate.addEventListener('stamping', ()=>{
+                        console.log('done2')
+                        done();
+                    });
+                });
+                it('should NOT still have `loading-content` attribute on itself', function () {
+                    expect(scInclude).to.have.HTMLAttribute('loading-content').equal(null);
+                });
+                it('should have `visibility` style set to `visible`', function () {
+                    expect(scInclude.style).to.have.property('visibility').equal('visible');
+                });
+            });
+        });
+
+    </script>
+
+</body>
+
+</html>

--- a/test/blocking-links/shadow-dom.html
+++ b/test/blocking-links/shadow-dom.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+
+    <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../../web-component-tester/browser.js"></script>
+    <script src="../helpers/chainable-methods-for-partial.js"></script>
+
+    <link rel="import" href="../../../polymer/polymer.html">
+
+    <!-- Step 1: import the element to test -->
+    <link rel="import" href="../../starcounter-include.html">
+    <script src="../helpers/WCT-Polyfill_bugs_workaround.js"></script>
+    <link rel="import" href="../../../enlighted-link/enlighted-link.html">
+</head>
+
+<body>
+
+    <div id="testFixtureConatiner"></div>
+
+    <script>
+        const COMPOSITIONS = {
+            BLOCKING:{
+                "stylesheet": `<link rel="stylesheet" href="/components/starcounter-include/sc/blocking-links/styles.css">`,
+                "enlighted-link": `<enlighted-link rel="import" href="/components/starcounter-include/sc/blocking-links/import.html"></enlighted-link>`
+            },
+            ASYNC:{
+                "stylesheet": `<link async rel="stylesheet" href="/components/starcounter-include/sc/blocking-links/styles.css">`,
+                "enlighted-link": `<enlighted-link async rel="import" href="/components/starcounter-include/sc/blocking-links/import.html"></enlighted-link>`
+            }
+        };
+
+        var scInclude, importedTemplate;
+        describe(`imported content`,()=>{
+            beforeEach(function (done) {
+                scInclude = document.createElement('starcounter-include');
+                testFixtureConatiner.appendChild(scInclude);
+                importedTemplate = scInclude.querySelector_template_for_buggy_polyfill();
+                importedTemplate.addEventListener('stamping', ()=>{
+                    setTimeout(done);
+                });
+                scInclude.viewModel = {
+                    App: {
+                        Html: `templateTo.html`,
+                        doesItWork: "worked!"
+                    }
+                };
+            });
+            afterEach(()=>{
+                testFixtureConatiner.innerHTML = '';
+            });
+
+            ['stylesheet', 'enlighted-link'].forEach((linkType)=>{
+                describe('when presentation is set (via `updateComposition`) to the one that contains a ', function () {
+                    describe(` \`${linkType}\` element without \`async\` attribute`, function () {
+                        beforeEach(function () {
+                            scInclude.updateComposition(COMPOSITIONS.BLOCKING[linkType]);
+                        });
+
+                        it('should set `loading-presentation` attribute on itself', function () {
+                            expect(scInclude).to.have.HTMLAttribute('loading-presentation').equal("");
+                        });
+                        it('should have `visibility` style set to `hidden`', function () {
+                            expect(scInclude.style).to.have.property('visibility').equal('hidden');
+                        });
+                        describe('after content is stamped, and all imports are loaded', ()=>{
+                            beforeEach(function (done) {
+                                setTimeout(done, 500);
+                            });
+                            it('should no longer have `loading-presentation` attribute on itself', function () {
+                                expect(scInclude).to.have.HTMLAttribute('loading-presentation').equal(null);
+                            });
+                            it('should have `visibility` style set to `visible`', function () {
+                                expect(scInclude.style).to.have.property('visibility').equal('visible');
+                            });
+                        });
+                    });
+                    describe(`\`${linkType}\` element with \`async\` attribute`, function () {
+                        beforeEach(function () {
+                            scInclude.updateComposition(COMPOSITIONS.BLOCKING[linkType]);
+                        });
+
+                        it('should set `loading-presentation` attribute on itself', function () {
+                            expect(scInclude).to.have.HTMLAttribute('loading-presentation').equal("");
+                        });
+                        it('should have `visibility` style set to `hidden`', function () {
+                            expect(scInclude.style).to.have.property('visibility').equal('hidden');
+                        });
+                        describe('after content is stamped, but before imports are loaded', ()=>{
+                            beforeEach(function (done) {
+                                setTimeout(done, 500);
+                            });
+                            it('should NOT still have `loading-presentation` attribute on itself', function () {
+                                expect(scInclude).to.have.HTMLAttribute('loading-presentation').equal(null);
+                            });
+                            it('should have `visibility` style set to `visible`', function () {
+                                expect(scInclude.style).to.have.property('visibility').equal('visible');
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    </script>
+
+</body>
+
+</html>

--- a/test/composition/fallback.html
+++ b/test/composition/fallback.html
@@ -47,7 +47,7 @@
         });
         it('should use the initial composition', function() {
             expect(scInclude.shadowRoot).to.be.not.null;
-            expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(REFERENCE_FALLBACK);
+            expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_FALLBACK);
         });
         describe('after partial property is replaced with a partial that contains a default composition', function() {
             beforeEach(function(done) {
@@ -75,11 +75,11 @@
                 scInclude.updateComposition(temporaryComposition);
             });
             it('should render the temporary composition', function() {
-                expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(temporaryComposition);
+                expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(temporaryComposition);
             });
             it('should return to fallback after resetting', function() {
                 scInclude.updateComposition(""); //this is how starcounter-layout-html-editor resets
-                expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(REFERENCE_FALLBACK);
+                expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_FALLBACK);
             });
             it('should NOT overwrite Composition$', function() {
                 expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.equal("");
@@ -90,10 +90,10 @@
                     scInclude.updateComposition(); //simulate notifyPath which can trigger updateComposition
                 });
                 it('should overwrite Composition$', function() {
-                    expect(scInclude.viewModel.CompositionProvider_0.Composition$.trim()).to.be.equal(temporaryComposition);
+                    expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(temporaryComposition);
                 });
                 it('should render the temporary composition', function() {
-                    expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(temporaryComposition);
+                    expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(temporaryComposition);
                 });
             });
         });

--- a/test/index.html
+++ b/test/index.html
@@ -41,7 +41,9 @@
             // warning on dropped support for non-namespaced view-models
             'non-namespaced/warning.html',
             'shadowRoot/basic.html',
-            'shadowRoot/smoke/webcomponents-webcomponentsjs-issues-648.html'
+            'shadowRoot/smoke/webcomponents-webcomponentsjs-issues-648.html',
+            'blocking-links/light-dom.html',
+            'blocking-links/shadow-dom.html'
         ];
 
 

--- a/test/mocked_sc_htmlmerger.js
+++ b/test/mocked_sc_htmlmerger.js
@@ -14,9 +14,10 @@ connect().use('/sc/htmlmerger', function fooMiddleware(req, res, next) {
         // res.write("Chunk");
         const parts = pair.split('=');
         const appName = parts[0];
-        const fileName = parts[1];
+        let fileName = parts[1];
         content += `<imported-template-scope scope="${appName}"><template><meta itemprop="juicy-composition-scope" content="${appName}"/></template>`;
         if(fileName){
+            fileName = fileName.replace('%2F','/');
             if(fs.existsSync(servingDirectory + fileName)){
                 content +=  fs.readFileSync(servingDirectory + fileName, 'utf8');
             } else {
@@ -26,8 +27,10 @@ connect().use('/sc/htmlmerger', function fooMiddleware(req, res, next) {
         content += `</imported-template-scope>`;
     })
     res.setHeader('Content-Type', 'text/html');
-    res.end(content);
-    next();
+    setTimeout(()=>{
+        res.end(content)
+        next();
+    }, 50);
 }).listen(9999, function() {
     console.log('Mocked SC Server running on 9999...');
 });

--- a/test/shadowRoot/basic.html
+++ b/test/shadowRoot/basic.html
@@ -7,6 +7,7 @@
     <title>starcounter-include composition basic test</title>
     <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../../web-component-tester/browser.js"></script>
+    <script src="../helpers/compareHTMLStrings.js"></script>
     <link rel="import" href="../../../polymer/polymer.html">
 
     <link rel="import" href="../../starcounter-include.html">
@@ -75,7 +76,7 @@
             it('should create shadowRoot with given Document Fragment', function () {
                 expect(scInclude).to.have.property('shadowRoot');
                 // expect(scInclude.shadowRoot).to.have.property('innerHTML', compositionTemplate.innerHTML);
-                expect(scInclude.shadowRoot.innerHTML).to.equal(composition);
+                expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(composition);
             });
             it('should distribute its children, which has `slot` attribute matching slot(content) tag within given shadow DOM', function () {
                 expect(scInclude.children[1].assignedSlot).to.be.not.null;

--- a/test/shadowRoot/smoke/webcomponents-webcomponentsjs-issues-648.html
+++ b/test/shadowRoot/smoke/webcomponents-webcomponentsjs-issues-648.html
@@ -48,7 +48,6 @@
                     div.setAttribute('slot', 'else');
                     div.innerHTML = 'Am I green?';
                     scInclude.appendChild(div);
-                    // expect(scInclude.shadowRoot.innerHTML).to.equal(compositionTemplate.innerHTML);
                     setTimeout(function(){
                         done();
                     });

--- a/test/view-model-attribute/cleanup_removed_partial_Layout.html
+++ b/test/view-model-attribute/cleanup_removed_partial_Layout.html
@@ -8,6 +8,7 @@
     <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
 
     <script src="../../../web-component-tester/browser.js"></script>
+    <script src="../helpers/compareHTMLStrings.js"></script>
 
     <link rel="import" href="../../starcounter-include.html">
 </head>
@@ -118,7 +119,7 @@
         chai.Assertion.addProperty('compositionCleanedUp', function () {
           var obj = chai.util.flag(this, 'object');
           new chai.Assertion(obj).to.be.instanceof(HTMLElement);
-          new chai.Assertion(obj.shadowRoot.innerHTML).to.equal(DEFAULT_COMPOSITION);
+          new chai.Assertion(obj.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(DEFAULT_COMPOSITION);
         });
     </script>
 

--- a/test/view-model-attribute/nested-html/property-set-before-CEupgrade.html
+++ b/test/view-model-attribute/nested-html/property-set-before-CEupgrade.html
@@ -53,7 +53,7 @@
                 const link = document.createElement('link');
                 link.rel = 'import';
                 link.href = '../../../starcounter-include.html';
-                link.addEventListener('load', ()=>{
+                customElements.whenDefined('starcounter-include').then(()=>{
                     done();
                 });
                 document.head.appendChild(link);


### PR DESCRIPTION
https://github.com/Starcounter/starcounter-include/issues/93

Done:
- [x] Support light and Shadow DOM,
- [x] opt-out capabilities with `async` attribute,
- [x] Cover race condition between resources load and changing composition or content,
- [x] Prepare for default custom-element styles Web Platform feature

Doubts:
1. [x] I'm still not sure whether it's better to implement `[loading-content],[loading-presentation]` using `attributeChangedCallback`, as this is a cost in run-time.
I thought about alternative solution, which adds `<style>:host([loading-content]),:host([loading-presentation]){visibility:hidden !important;}</style>` to the shadow root. But then we would have to update BlendingEditor to ignore it while observing and changing `element.shadowRoot`, update `partialToStandaloneHTMLProvider` to include it as well, and what is worse require all existing composition to be updated. @alshakero, @warpech WDYT? - Decided to go with `[loading-content],[loading-presentation]` to minimize migration burden.

Still missing:
 - [x] tests,
 - [ ] Edge support, for stamping light DOM styles (potentially a separate issue)
 - [ ] Full support for `<enlighted-link>` (potentially a thing to fix there)
 - [ ] README notes