### PR TITLE
be more radical by presenting a non-namespaced view-model in starcoun…

### DIFF
--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -470,7 +470,8 @@ version: 5.1.1
                 element.wasWarned = true;
             }
             else if(element.wasWarned) {
-                element.removeAttribute("style");
+                element.style.outline = null;
+                element.style.outlineOffset = null;
                 element.wasWarned = false;
             }
         };

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -464,8 +464,9 @@ version: 5.1.1
             if(viewModel && typeof viewModel.Html !== 'undefined'){
                 console.warn(`The view ${viewModel.Html} is enclosed in a red-dotted line, because it is incorrectly provided to <starcounter-include> without an app namespace. Your options are: 
 1. Request the blendable Json subtree with Self.GET. Then you can keep to use <starcounter-include> in HTML.
-2. Or, replace <starcounter-include> in HTML with <div><imported-template model="{{viewModel}}" href="{{viewModel.Html}}"></imported-template></div> to insert the Json subtree in a non-blendable fashion. Then you can keep your C# that assigns a Json instance to a parent object without Self.GET.`, viewModel, element);
-                element.setAttribute("style", "outline: 4px red dotted; outline-offset: -4px");
+2. Or, replace <starcounter-include> in HTML with <div><imported-template model="{{viewModel}}" href="{{viewModel.Html}}"></imported-template></div> to insert the Json subtree in a non-blendable fashion. Then you can keep your C# that assigns a Json instance to a parent object without Self.GET. In that case the view does not support declarative-shadow-dom.`, viewModel, element);
+                element.style.outline = "4px red dotted";
+                element.style.outlineOffset = "-4px";
                 element.wasWarned = true;
             }
             else if(element.wasWarned) {

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -462,9 +462,11 @@ version: 5.1.1
          */
         function checkForNonNamespaced(viewModel, element){
             if(viewModel && typeof viewModel.Html !== 'undefined'){
-                console.warn(`The view ${viewModel.Html} is enclosed in a red-dotted line, because it is incorrectly provided to <starcounter-include> without an app namespace. Your options are: 
-1. Request the blendable Json subtree with Self.GET. Then you can keep to use <starcounter-include> in HTML.
-2. Or, replace <starcounter-include> in HTML with <div><imported-template model="{{viewModel}}" href="{{viewModel.Html}}"></imported-template></div> to insert the Json subtree in a non-blendable fashion. Then you can keep your C# that assigns a Json instance to a parent object without Self.GET. In that case the view does not support declarative-shadow-dom.`, viewModel, element);
+                console.warn(`The view ${viewModel.Html} is enclosed in a red-dotted line, because it is incorrectly provided to <starcounter-include> without an app namespace. Your options are to either: 
+- Make it blendable by using Self.GET on server-side, or
+- Use <imported-template> instead of <starcounter-include> and remove declarative-shadow-dom from the nested view
+
+Read more at: https://starcounter.io/starcounter-include-non-namespaced-partial-view-models/`, viewModel, element);
                 element.style.outline = "4px red dotted";
                 element.style.outlineOffset = "-4px";
                 element.wasWarned = true;

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -462,11 +462,15 @@ version: 5.1.1
          */
         function checkForNonNamespaced(viewModel, element){
             if(viewModel && typeof viewModel.Html !== 'undefined'){
-                console.warn(`Your view-model is probably not namespaced!
-`, viewModel, `
-We no longer support those.
-Please make sure it's a result of \`Self.GET\` on serverside. If it's not a result of blending, then replace \`<starcounter-include view-model="{{viewModel}}">\` with  \`<div><imported-template model="{{viewModel}}" href="{{viewModel.Html}}"></imported-template></div>\`.
-`, element);
+                console.warn(`The view ${viewModel.Html} is enclosed in a red-dotted line, because it is incorrectly provided to <starcounter-include> without an app namespace. Your options are: 
+1. Request the blendable Json subtree with Self.GET. Then you can keep to use <starcounter-include> in HTML.
+2. Or, replace <starcounter-include> in HTML with <div><imported-template model="{{viewModel}}" href="{{viewModel.Html}}"></imported-template></div> to insert the Json subtree in a non-blendable fashion. Then you can keep your C# that assigns a Json instance to a parent object without Self.GET.`, viewModel, element);
+                element.setAttribute("style", "outline: 4px red dotted; outline-offset: -4px");
+                element.wasWarned = true;
+            }
+            else if(element.wasWarned) {
+                element.removeAttribute("style");
+                element.wasWarned = false;
             }
         };
 

--- a/test/non-namespaced/warning.html
+++ b/test/non-namespaced/warning.html
@@ -43,7 +43,7 @@
                 "doesItWork": "works!"
             });
 
-            var CSS_OUTLINE = "outline: 4px red dotted; outline-offset: -4px";
+            var CSS_OUTLINE = "outline:";
 
             // var func = () => ({foo: 1})
 
@@ -80,7 +80,7 @@
                     expect(console.warn.args[0]).to.contain(scInclude.viewModel);
                 });
                 it('should give a red outline to starcounter-include', function(){
-                    expect(scInclude.getAttribute("style")).to.equal(CSS_OUTLINE);
+                    expect(scInclude.getAttribute("style")).to.contain(CSS_OUTLINE);
                 });
             });
             describe('in JS', function(){
@@ -108,7 +108,7 @@
                         expect(console.warn.args[0]).to.contain(scInclude.viewModel);
                     });
                     it('should give a red outline to starcounter-include', function(){
-                        expect(scInclude.getAttribute("style")).to.equal(CSS_OUTLINE);
+                        expect(scInclude.getAttribute("style")).to.contain(CSS_OUTLINE);
                     });
                 });
                 describe('via property,', function(){
@@ -130,7 +130,7 @@
                         expect(console.warn.args[0]).to.contain(scInclude.viewModel);
                     });
                     it('should give a red outline to starcounter-include', function(){
-                        expect(scInclude.getAttribute("style")).to.equal(CSS_OUTLINE);
+                        expect(scInclude.getAttribute("style")).to.contain(CSS_OUTLINE);
                     });
                 });
             });

--- a/test/non-namespaced/warning.html
+++ b/test/non-namespaced/warning.html
@@ -43,6 +43,8 @@
                 "doesItWork": "works!"
             });
 
+            var CSS_OUTLINE = "outline: 4px red dotted; outline-offset: -4px";
+
             // var func = () => ({foo: 1})
 
             beforeEach(function (done) {
@@ -65,7 +67,7 @@
                 });
                 it('should throw a warning about "namespaced" view-model, with a hint how to fix that ("Self.GET", "imported-template")', function(){
                     expect(console.warn).to.be.called;
-                    expect(console.warn.args[0].join()).to.contain('namespaced');
+                    expect(console.warn.args[0].join()).to.contain('namespace');
                     expect(console.warn.args[0].join()).to.contain('Self.GET');
                     expect(console.warn.args[0].join()).to.contain('imported-template');
                 });
@@ -76,6 +78,9 @@
                 it('should throw a warning about "namespaced" view-model, that contains a reference to the view-model', function(){
                     expect(console.warn).to.be.called;
                     expect(console.warn.args[0]).to.contain(scInclude.viewModel);
+                });
+                it('should give a red outline to starcounter-include', function(){
+                    expect(scInclude.getAttribute("style")).to.equal(CSS_OUTLINE);
                 });
             });
             describe('in JS', function(){
@@ -90,7 +95,7 @@
                     });
                     it('should throw a warning about "namespaced" view-model, with a hint how to fix that ("Self.GET", "imported-template")', function(){
                         expect(console.warn).to.be.called;
-                        expect(console.warn.args[0].join()).to.contain('namespaced');
+                        expect(console.warn.args[0].join()).to.contain('namespace');
                         expect(console.warn.args[0].join()).to.contain('Self.GET');
                         expect(console.warn.args[0].join()).to.contain('imported-template');
                     });
@@ -101,6 +106,9 @@
                     it('should throw a warning, that contains a reference to the view-model', function(){
                         expect(console.warn).to.be.called;
                         expect(console.warn.args[0]).to.contain(scInclude.viewModel);
+                    });
+                    it('should give a red outline to starcounter-include', function(){
+                        expect(scInclude.getAttribute("style")).to.equal(CSS_OUTLINE);
                     });
                 });
                 describe('via property,', function(){
@@ -109,7 +117,7 @@
                     });
                     it('should throw a warning about "namespaced" view-model, with a hint how to fix that ("Self.GET", "imported-template")', function(){
                         expect(console.warn).to.be.called;
-                        expect(console.warn.args[0].join()).to.contain('namespaced');
+                        expect(console.warn.args[0].join()).to.contain('namespace');
                         expect(console.warn.args[0].join()).to.contain('Self.GET');
                         expect(console.warn.args[0].join()).to.contain('imported-template');
                     });
@@ -120,6 +128,9 @@
                     it('should throw a warning, that contains a reference to the view-model', function(){
                         expect(console.warn).to.be.called;
                         expect(console.warn.args[0]).to.contain(scInclude.viewModel);
+                    });
+                    it('should give a red outline to starcounter-include', function(){
+                        expect(scInclude.getAttribute("style")).to.equal(CSS_OUTLINE);
                     });
                 });
             });


### PR DESCRIPTION
…ter-include within a red-dotted outline

Screenshots:

- https://drive.google.com/open?id=1di0Toil0QXRoVvIzj1S1JIXwswA5HZdt
- https://drive.google.com/open?id=1z2LvfWOP8GKI_Mq0p2hTbL7sdxw_6kcJ

This was discussed with @mmnosek and @miyconst.

In the beginning I wanted to be more radical by blurring the view or hiding it completely. This was Konstantin's suggestion to use the outline.