### PR TITLE
Move Blending app workaround here,

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ Property   | Options           | Default | Description
 `partial`   | *Object*          |         | Object containing partial JSON view-model, bindable with Polymer
 `partialId` | *String*          |         | Partial Id used to identify partial, usually it's fetched from `partial.{compositionProvider}.PartialId`.
 `viewModel` | *Object*          |         | Alias for `partial`
-`compositionProvider` | *String* | `CompositionProvider_0` | Key/app name of composition provider. could be overwritten per instance `scInclude.compositionProvider` or globally by changing the prototype, like: `customElements.get('starcounter-include').prototype.compositionProvider = 'CustomProvider_7'`
+`compositionProvider` | *String* | getter, see the source code | Key/app name of composition provider. could be overwritten per instance `scInclude.compositionProvider` or globally by changing the prototype, like: `customElements.get('starcounter-include').prototype.compositionProvider = 'CustomProvider_7'`.
+For the requirements on the `partial` object to read this from, see the source code and try to match the condition with your case.
 
 ## Events
 

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -125,6 +125,25 @@ version: 5.2.0
                     }
                 });
             }
+
+            /**
+             * Composition provider key.
+             * The place which the element will check for custom compositions.
+             * Could be overwritten per instance or globally if you change the prototype.
+             * Could be static but due to flaws of the Blending app needs to be a getter.
+             * @type {String}
+             *
+             * 1. `LayoutInfo` is the only response added via `JsonResponseMerger.RegisterMergeCallback`,
+             * 2. `JsonResponseMerger.RegisterMergeCallback` adds siblings after any other regularly blended view-models => they get highest numbers,
+             * 3.  1 & 2 => composition provider is the last of BlendingProvider_* ,
+             * 4.  BlendingProvider has 3 responses at most.
+             *
+             * However, regardless of the reasons above, due to some weirdness and bugs of ViewKeeper it is not always the last one, and we should pick `_0` if it has composition.
+             * FIXME(tomalec): Please.
+            */
+            get compositionProvider(){
+                return this.partial.BlendingProvider_0 && (typeof this.partial.BlendingProvider_0.Composition$ !== 'undefined') && 'BlendingProvider_0' || this.partial.BlendingProvider_2 && 'BlendingProvider_2' || 'BlendingProvider_1';
+            }
             /**
              * Stamp `imported-template` into Light DOM,
              * attach `stamping` listener to gather Shadow DOM layout compositions
@@ -486,13 +505,6 @@ version: 5.2.0
             }
             return range.createContextualFragment(htmlStr);
         }
-        /**
-         * Composition provider key.
-         * The place which the element will check for custom compositions.
-         * Could be overwritten per instance or globally if you change the prototype.
-         * @type {String}
-         */
-        StarcounterIncludePrototype.compositionProvider = 'CompositionProvider_0';
 
         /**
          * Check if given viewModel is non-namespace (contains `.Html` property)
@@ -502,7 +514,7 @@ version: 5.2.0
          */
         function checkForNonNamespaced(viewModel, element){
             if(viewModel && typeof viewModel.Html !== 'undefined'){
-                console.warn(`The view ${viewModel.Html} is enclosed in a red-dotted line, because it is incorrectly provided to <starcounter-include> without an app namespace. Your options are to either: 
+                console.warn(`The view ${viewModel.Html} is enclosed in a red-dotted line, because it is incorrectly provided to <starcounter-include> without an app namespace. Your options are to either:
 - Make it blendable by using Self.GET on server-side, or
 - Use <imported-template> instead of <starcounter-include> and remove declarative-shadow-dom from the nested view
 

--- a/test/composition/custom.html
+++ b/test/composition/custom.html
@@ -21,7 +21,7 @@
     <test-fixture id="initial-fixture">
         <template>
             <starcounter-include view-model="{
-                &quot;CompositionProvider_0&quot;: {
+                &quot;BlendingProvider_0&quot;: {
                     &quot;PartialId&quot;: &quot;given PartialId&quot;,
                     &quot;Composition$&quot;: &quot;customComposition!<slot></slot>&quot;
                 },
@@ -73,7 +73,7 @@
                 var composition$;
                 var temporaryComposition = "temporary composition";
                 beforeEach(function () {
-                    composition$ = scInclude.viewModel.CompositionProvider_0.Composition$;
+                    composition$ = scInclude.viewModel.BlendingProvider_0.Composition$;
                     scInclude.updateComposition(temporaryComposition);
                 });
                 it('should render the temporary composition', function () {
@@ -85,7 +85,7 @@
                     expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_DEFAULT);
                 });
                 it('should NOT overwrite Composition$', function () {
-                    expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.equal(composition$);
+                    expect(scInclude.viewModel.BlendingProvider_0.Composition$).to.be.equal(composition$);
                 });
                 describe('after saveLayout() is called', function () {
                     beforeEach(function () {
@@ -93,7 +93,7 @@
                         scInclude.updateComposition(); //simulate notifyPath which can trigger updateComposition
                     });
                     it('should overwrite Composition$', function () {
-                        expect(scInclude.viewModel.CompositionProvider_0.Composition$.trim()).to.be.equal(temporaryComposition);
+                        expect(scInclude.viewModel.BlendingProvider_0.Composition$.trim()).to.be.equal(temporaryComposition);
                     });
                     it('should render the temporary composition', function () {
                         expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(temporaryComposition);

--- a/test/composition/default-declarative-shadow-dom.html
+++ b/test/composition/default-declarative-shadow-dom.html
@@ -22,7 +22,7 @@
     <test-fixture id="default-composition">
         <template>
             <starcounter-include partial="{
-                &quot;CompositionProvider_0&quot;: {
+                &quot;BlendingProvider_0&quot;: {
                     &quot;PartialId&quot;: &quot;given PartialId&quot;,
                     &quot;Composition$&quot;: &quot;&quot;
                 },
@@ -36,7 +36,7 @@
     <test-fixture id="other-presentation">
         <template>
             <starcounter-include partial="{
-                &quot;CompositionProvider_0&quot;: {
+                &quot;BlendingProvider_0&quot;: {
                     &quot;PartialId&quot;: &quot;given PartialId&quot;,
                     &quot;Composition$&quot;: &quot;&quot;
                 },
@@ -62,7 +62,7 @@
 
         var scInclude;
         var alternativePartial = {
-            "CompositionProvider_0": {
+            "BlendingProvider_0": {
                 "PartialId": "given PartialId",
                 "Composition$": "",
                 "ViewUris": []
@@ -73,7 +73,7 @@
             }
         };
         var alternativePartialWithTwo = {
-            "CompositionProvider_0": {
+            "BlendingProvider_0": {
                 "PartialId": "given PartialId",
                 "Composition$": "custom!",
                 "ViewUris": ["template_w_declarative-shadow-dom.html"]
@@ -125,7 +125,7 @@
             var composition$;
             var temporaryComposition = "temporary composition";
             beforeEach(function() {
-                composition$ = scInclude.viewModel.CompositionProvider_0.Composition$;
+                composition$ = scInclude.viewModel.BlendingProvider_0.Composition$;
                 scInclude.updateComposition(temporaryComposition);
             });
             it('should render the temporary composition', function() {
@@ -137,7 +137,7 @@
                     .sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_COMPOSITION);
             });
             it('should NOT overwrite Composition$', function() {
-                expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.equal(composition$);
+                expect(scInclude.viewModel.BlendingProvider_0.Composition$).to.be.equal(composition$);
             });
             describe('after saveLayout() is called', function() {
                 beforeEach(function() {
@@ -145,7 +145,7 @@
                     scInclude.updateComposition(); //simulate notifyPath which can trigger updateComposition
                 });
                 it('should overwrite Composition$', function() {
-                    expect(scInclude.viewModel.CompositionProvider_0.Composition$.trim()).to.be.equal(temporaryComposition);
+                    expect(scInclude.viewModel.BlendingProvider_0.Composition$.trim()).to.be.equal(temporaryComposition);
                 });
                 it('should render the temporary composition', function() {
                     expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(temporaryComposition);
@@ -166,7 +166,7 @@
                 var composition$;
                 var temporaryComposition = "temporary composition";
                 beforeEach(function() {
-                    composition$ = scInclude.viewModel.CompositionProvider_0.Composition$;
+                    composition$ = scInclude.viewModel.BlendingProvider_0.Composition$;
                     scInclude.updateComposition(temporaryComposition);
                 });
                 it('should render the temporary composition', function() {
@@ -178,7 +178,7 @@
                         .sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_COMPOSITION + REFERENCE_ALTERNATIVE_COMPOSITION);
                 });
                 it('should NOT overwrite Composition$', function() {
-                    expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.equal(composition$);
+                    expect(scInclude.viewModel.BlendingProvider_0.Composition$).to.be.equal(composition$);
                 });
                 describe('after saveLayout() is called', function() {
                     beforeEach(function() {
@@ -186,7 +186,7 @@
                         scInclude.updateComposition(); //simulate notifyPath which can trigger updateComposition
                     });
                     it('should overwrite Composition$', function() {
-                        expect(scInclude.viewModel.CompositionProvider_0.Composition$.trim()).to.be.equal(temporaryComposition);
+                        expect(scInclude.viewModel.BlendingProvider_0.Composition$.trim()).to.be.equal(temporaryComposition);
                     });
                     it('should render the temporary composition', function() {
                         expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(temporaryComposition);

--- a/test/composition/fallback.html
+++ b/test/composition/fallback.html
@@ -21,7 +21,7 @@
     <test-fixture id="initial-fixture">
         <template>
             <starcounter-include partial="{
-                &quot;CompositionProvider_0&quot;: {
+                &quot;BlendingProvider_0&quot;: {
                     &quot;PartialId&quot;: &quot;given PartialId&quot;,
                     &quot;Composition$&quot;: &quot;&quot;
                 },
@@ -82,7 +82,7 @@
                 expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_FALLBACK);
             });
             it('should NOT overwrite Composition$', function() {
-                expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.equal("");
+                expect(scInclude.viewModel.BlendingProvider_0.Composition$).to.be.equal("");
             });
             describe('after saveLayout() is called', function() {
                 beforeEach(function() {
@@ -90,7 +90,7 @@
                     scInclude.updateComposition(); //simulate notifyPath which can trigger updateComposition
                 });
                 it('should overwrite Composition$', function() {
-                    expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(temporaryComposition);
+                    expect(scInclude.viewModel.BlendingProvider_0.Composition$).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(temporaryComposition);
                 });
                 it('should render the temporary composition', function() {
                     expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(temporaryComposition);

--- a/test/composition/parent-declarative-shadow-dom.html
+++ b/test/composition/parent-declarative-shadow-dom.html
@@ -22,7 +22,7 @@
     <test-fixture id="parent-composition">
         <template>
             <starcounter-include partial="{
-                &quot;CompositionProvider_0&quot;: {
+                &quot;BlendingProvider_0&quot;: {
                     &quot;PartialId&quot;: &quot;given PartialId&quot;,
                     &quot;Composition$&quot;: &quot;&quot;
                 },
@@ -40,7 +40,7 @@
     <test-fixture id="other-presentation">
         <template>
             <starcounter-include partial="{
-                &quot;CompositionProvider_0&quot;: {
+                &quot;BlendingProvider_0&quot;: {
                     &quot;PartialId&quot;: &quot;given PartialId&quot;,
                     &quot;Composition$&quot;: &quot;&quot;
                 },
@@ -70,7 +70,7 @@
 
         var scInclude;
         var alternativePartial = {
-            "CompositionProvider_0": {
+            "BlendingProvider_0": {
                 "PartialId": "given PartialId",
                 "Composition$": "",
                 "ViewUris": []
@@ -81,7 +81,7 @@
             }
         };
         var alternativePartialWithTwo = {
-            "CompositionProvider_0": {
+            "BlendingProvider_0": {
                 "PartialId": "given PartialId",
                 "Composition$": "custom!",
                 "ViewUris": ["template_w_declarative-shadow-dom.html"]
@@ -129,7 +129,7 @@
             var composition$;
             var temporaryComposition = "temporary composition";
             beforeEach(function() {
-                composition$ = scInclude.viewModel.CompositionProvider_0.Composition$;
+                composition$ = scInclude.viewModel.BlendingProvider_0.Composition$;
                 scInclude.updateComposition(temporaryComposition);
             });
             it('should render the temporary composition', function() {
@@ -141,7 +141,7 @@
                     .sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_COMPOSITION);
             });
             it('should NOT overwrite Composition$', function() {
-                expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.equal(composition$);
+                expect(scInclude.viewModel.BlendingProvider_0.Composition$).to.be.equal(composition$);
             });
             describe('after saveLayout() is called', function() {
                 beforeEach(function() {
@@ -149,7 +149,7 @@
                     scInclude.updateComposition(); //simulate notifyPath which can trigger updateComposition
                 });
                 it('should overwrite Composition$', function() {
-                    expect(scInclude.viewModel.CompositionProvider_0.Composition$.trim()).to.be.equal(temporaryComposition);
+                    expect(scInclude.viewModel.BlendingProvider_0.Composition$.trim()).to.be.equal(temporaryComposition);
                 });
                 it('should render the temporary composition', function() {
                     expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(temporaryComposition);
@@ -170,7 +170,7 @@
                 var composition$;
                 var temporaryComposition = "temporary composition";
                 beforeEach(function() {
-                    composition$ = scInclude.viewModel.CompositionProvider_0.Composition$;
+                    composition$ = scInclude.viewModel.BlendingProvider_0.Composition$;
                     scInclude.updateComposition(temporaryComposition);
                 });
                 it('should render the temporary composition', function() {
@@ -183,7 +183,7 @@
                         .sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_COMPOSITION);
                 });
                 it('should NOT overwrite Composition$', function() {
-                    expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.equal(composition$);
+                    expect(scInclude.viewModel.BlendingProvider_0.Composition$).to.be.equal(composition$);
                 });
                 describe('after saveLayout() is called', function() {
                     beforeEach(function() {
@@ -191,7 +191,7 @@
                         scInclude.updateComposition(); //simulate notifyPath which can trigger updateComposition
                     });
                     it('should overwrite Composition$', function() {
-                        expect(scInclude.viewModel.CompositionProvider_0.Composition$.trim()).to.be.equal(temporaryComposition);
+                        expect(scInclude.viewModel.BlendingProvider_0.Composition$.trim()).to.be.equal(temporaryComposition);
                     });
                     it('should render the temporary composition', function() {
                         expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(temporaryComposition);

--- a/test/deprecated-partial-attrib/warning.html
+++ b/test/deprecated-partial-attrib/warning.html
@@ -23,7 +23,7 @@
             <!-- nest to workaround test-fixture bug -->
             <div>
                 <starcounter-include partial="{
-                        &quot;CompositionProvider_0&quot;: {
+                        &quot;BlendingProvider_0&quot;: {
                             &quot;PartialId&quot;: &quot;given PartialId&quot;
                         },
                         &quot;Html&quot;: &quot;../templateToInclude.html&quot;,

--- a/test/helpers/composition-fixtures.js
+++ b/test/helpers/composition-fixtures.js
@@ -12,7 +12,7 @@ const REFERENCE_FALLBACK = useShadowDOMV1 ? `<style>:host{display:block;}</style
 
 function partialWithCustom() {
     return {
-        "CompositionProvider_0": {
+        "BlendingProvider_0": {
             "PartialId": "given PartialId",
             "Composition$": "customComposition!<slot></slot>"
         },
@@ -25,7 +25,7 @@ function partialWithCustom() {
 
 function partialWithDefault() {
     return {
-        "CompositionProvider_0": {
+        "BlendingProvider_0": {
             "PartialId": "given PartialId",
             "Composition$": ""
         },
@@ -38,7 +38,7 @@ function partialWithDefault() {
 
 function partialWithFallback() {
     return {
-        "CompositionProvider_0": {
+        "BlendingProvider_0": {
             "PartialId": "given PartialId",
             "Composition$": ""
         },

--- a/test/partialId-property/reflect-partialId-to-attribute.html
+++ b/test/partialId-property/reflect-partialId-to-attribute.html
@@ -23,7 +23,8 @@
             <!-- nest to workaround test-fixture bug -->
             <div>
                 <starcounter-include viewModel="{
-                    &quot;CompositionProvider_0&quot;: {
+                    &quot;BlendingProvider_0&quot;: {
+                        &quot;Composition$&quot;: &quot;&quot;,
                         &quot;PartialId&quot;: &quot;given PartialId&quot;
                     },
                     &quot;Html&quot;: &quot;../templateToInclude.html&quot;,
@@ -64,7 +65,7 @@
     <test-fixture id="no-CompositionProvider.PartialId">
         <template>
             <div>
-                <starcounter-include partial="{&quot;Html&quot;: &quot;../old_templateToInclude.html&quot;, &quot;doesItWork&quot;: &quot;worked!&quot;, &quot;CompositionProvider_0&quot;: {}}"></starcounter-include>
+                <starcounter-include partial="{&quot;Html&quot;: &quot;../old_templateToInclude.html&quot;, &quot;doesItWork&quot;: &quot;worked!&quot;, &quot;BlendingProvider_0&quot;: {}}"></starcounter-include>
             </div>
         </template>
     </test-fixture>
@@ -72,7 +73,7 @@
         <template>
             <div>
                 <starcounter-include partial="{
-                    &quot;CompositionProvider_0&quot;: {
+                    &quot;BlendingProvider_0&quot;: {
                         &quot;PartialId&quot;: &quot;old PartialId&quot;,
                     },
                     &quot;Html&quot;: &quot;../templateToInclude.html&quot;,
@@ -87,7 +88,8 @@
         var scInclude;
         function getFullViewModel() {
           return {
-              "CompositionProvider_0": {
+              "BlendingProvider_0": {
+                  "Composition$": "", // <-- this requirement is put on us by a bug in ViewKeeper
                   "PartialId": "given PartialId"
               },
               "Html": "../templateToInclude.html",
@@ -96,7 +98,8 @@
         }
         function getNewViewModel() {
           return {
-            "CompositionProvider_0": {
+            "BlendingProvider_0": {
+                "Composition$": "", // <-- this requirement is put on us by a bug in ViewKeeper
                 "PartialId": "new PartialId"
             },
             "Html": "../templateToInclude.html",
@@ -120,7 +123,7 @@
             expect(scInclude.partialId).to.equal('new PartialId');
             expect(scInclude).to.have.HTMLAttribute('partial-id').equal('new PartialId');
         });
-        it('when it was set, then changed with Polymer dom-bind (`CompositionProvider_0` object), should reflect this change', function (done) {
+        it('when it was set, then changed with Polymer dom-bind (`BlendingProvider_0` object), should reflect this change', function (done) {
             var domBind;
             container = fixture('dom-bind');
             domBind = container.querySelector('dom-bind');
@@ -130,7 +133,8 @@
                 expect(scInclude.partialId).to.equal('given PartialId');
                 expect(scInclude).to.have.HTMLAttribute('partial-id').equal('given PartialId');
                 // change .PartialId
-                domBind.set('viewModel.CompositionProvider_0', {PartialId: "new PartialId"});
+                domBind.set('viewModel.BlendingProvider_0', {
+                    Composition$: "", PartialId: "new PartialId"});
                 setTimeout(function oncePolymerNotificationPropagated() {
                     expect(scInclude.partialId).to.equal('new PartialId');
                     expect(scInclude).to.have.HTMLAttribute('partial-id').equal('new PartialId');
@@ -138,7 +142,7 @@
                 });
             }, 100);
         });
-        it('when it was set, then changed with Polymer dom-bind (just `CompositionProvider_0.PartialId` property), should reflect this change', function (done) {
+        it('when it was set, then changed with Polymer dom-bind (just `BlendingProvider_0.PartialId` property), should reflect this change', function (done) {
             var domBind;
             container = fixture('dom-bind');
             domBind = container.querySelector('dom-bind');
@@ -148,7 +152,7 @@
                 expect(scInclude.partialId).to.equal('given PartialId');
                 expect(scInclude).to.have.HTMLAttribute('partial-id').equal('given PartialId');
                 // change .PartialId
-                domBind.set('viewModel.CompositionProvider_0.PartialId', 'new PartialId');
+                domBind.set('viewModel.BlendingProvider_0.PartialId', 'new PartialId');
                 setTimeout(function oncePolymerNotificationPropagated() {
                     expect(scInclude.partialId).to.equal('new PartialId');
                     expect(scInclude).to.have.HTMLAttribute('partial-id').equal('new PartialId');

--- a/test/shadowRoot/basic.html
+++ b/test/shadowRoot/basic.html
@@ -58,15 +58,15 @@
             });
         });
 
-        describe('when `.CompositionProvider_0.Composition$` property is set', function () {
+        describe('when `.BlendingProvider_0.Composition$` property is set', function () {
             beforeEach(function (done) {
                 container = fixture('element');
                 domBind = container.querySelector('dom-bind');
                 // domBind.addEventListener('dom-change', function waitForDomBind(){
                     scInclude = container.querySelector('starcounter-include');
                     composition = document.querySelector('#composition').innerHTML;
-                    domBind.set('partial', {CompositionProvider_0:{Composition$: null}});
-                    domBind.set('partial.CompositionProvider_0.Composition$', composition);
+                    domBind.set('partial', {BlendingProvider_0:{Composition$: null}});
+                    domBind.set('partial.BlendingProvider_0.Composition$', composition);
                     // setTimeout(function waitForPolyfilledUpgrade(){
                         done();
                     // },100);

--- a/test/shadowRoot/smoke/webcomponents-webcomponentsjs-issues-648.html
+++ b/test/shadowRoot/smoke/webcomponents-webcomponentsjs-issues-648.html
@@ -32,7 +32,7 @@
                 scInclude = fixture('element');
                 compositionTemplate = document.querySelector('#composition');
     			scInclude.viewModel = {
-    				CompositionProvider_0:{
+    				BlendingProvider_0:{
     					Composition$: compositionTemplate.innerHTML
     				}
     			};

--- a/test/view-model-attribute/cleanup_removed_partial_Layout.html
+++ b/test/view-model-attribute/cleanup_removed_partial_Layout.html
@@ -34,7 +34,7 @@
             var instance;
             var model = {
                 "Html": "../templateToInclude.html",
-                "CompositionProvider_0": {
+                "BlendingProvider_0": {
                     "Composition$": 'a Composition',
                     "PartialId": "given PartialId"
                 },
@@ -96,7 +96,7 @@
                     expect(instance).to.have.compositionAttached;
                     instance.viewModel = {
                         "Html": "../templateToInclude.html",
-                        "CompositionProvider_0": {
+                        "BlendingProvider_0": {
                             "Composition$": "",
                             "PartialId": ""
                         },

--- a/test/view-model-attribute/cleanup_removed_partial_PartialId.html
+++ b/test/view-model-attribute/cleanup_removed_partial_PartialId.html
@@ -30,7 +30,8 @@
             var instance;
             var model = {
                 "Html": "../templateToInclude.html",
-                "CompositionProvider_0": {
+                "BlendingProvider_0": {
+                    "Composition$": "", // <-- this requirement is put on us by a bug in ViewKeeper
                     "PartialId": "templateToInclude.html"
                 },
                 "doesItWork": "works!"
@@ -91,7 +92,8 @@
                     expectPartialToBeAttached();
                     instance.viewModel = {
                         "Html": "../templateToInclude.html",
-                        "CompositionProvider_0": {
+                        "BlendingProvider_0": {
+                            "Composition$": "", // <-- this requirement is put on us by a bug in ViewKeeper
                             "PartialId": ""
                         },
                         "doesItWork": "works!"
@@ -102,8 +104,8 @@
             });
 
             function expectPartialToBeAttached() {
-                expect(instance).to.have.HTMLAttribute('partial-id').equal(model.CompositionProvider_0.PartialId);
-                expect(instance.partialId).to.be.equal(model.CompositionProvider_0.PartialId);
+                expect(instance).to.have.HTMLAttribute('partial-id').equal(model.BlendingProvider_0.PartialId);
+                expect(instance.partialId).to.be.equal(model.BlendingProvider_0.PartialId);
             }
 
             function expectPartialToBeCleanedUp() {


### PR DESCRIPTION
to remove another hack needed to apply this hack.

Git blame hint, to track the history of this condition see
https://github.com/Starcounter/Blending/blame/dce59aa6fdf8d64b6a820d53fb1b9ee35ead3abf/src/BlendingProvider/Composition/Api/Middleware.cs#L22-L34

Step to solve https://github.com/Starcounter/HeadsOmni/issues/272

⚠️ This is a breaking change, will break when used in older versions of Blending/CompositionProvider.


Please review also the changes in tests and README.

Sorry I was not able to explain the condition and rationale behind it any better.