### PR TITLE
Add a reference to the element that uses partial attribute

### DIFF
--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -12,8 +12,8 @@ version: 5.3.0
 
 <script>
     (function() {
-        function warnAboutDeprecatedPartial() {
-            console.warn('`partial` attribute and property are deprecated from `starcounter-include` in favour of (viewModel property or view-model attribute), they will soon be no longer be supported');
+        function warnAboutDeprecatedPartial(element) {
+            console.warn('`partial` attribute and property are deprecated from `starcounter-include` in favour of (viewModel property or view-model attribute), they will soon be no longer be supported', element);
         }
         const BLOCKING_LINKS_SELECTOR = 'link[rel="stylesheet"]';
         const DEFAULT_SHADOW_DOM_PRESENTATION_SELECTOR = 'template[is="declarative-shadow-dom"][presentation=default],template[is="declarative-shadow-dom"]:not([presentation])';
@@ -64,7 +64,7 @@ version: 5.3.0
                 var viewModel = this.viewModel || this.partial || undefined;
 
                 if(this.partial) {
-                    warnAboutDeprecatedPartial();
+                    warnAboutDeprecatedPartial(this);
                 }
 
                 checkForNonNamespaced(viewModel, this);
@@ -80,7 +80,7 @@ version: 5.3.0
                 Object.defineProperties(this, {
                     partial: {
                         set: function(newValue) {
-                            warnAboutDeprecatedPartial();
+                            warnAboutDeprecatedPartial(this);
                             this.viewModel = newValue;
                         },
                         get: function() {
@@ -199,7 +199,7 @@ version: 5.3.0
                     break;
                 case "partial":
                     if(!oldVal /* to warn only once */) {
-                        warnAboutDeprecatedPartial();
+                        warnAboutDeprecatedPartial(this);
                     }
                     this.viewModel = partialAttributeToProperty(this, newVal);
                     break;
@@ -356,7 +356,7 @@ version: 5.3.0
         // Polymer doesn't set props on its own components, rather, it calls this function
         StarcounterIncludePrototype._setPendingProperty = function (path, value) {
             if(path === 'partial') {
-                warnAboutDeprecatedPartial();
+                warnAboutDeprecatedPartial(this);
             }
             this[path] = value;
         }
@@ -503,7 +503,7 @@ version: 5.3.0
          */
         function checkForNonNamespaced(viewModel, element){
             if(viewModel && typeof viewModel.Html !== 'undefined'){
-                console.warn(`The view ${viewModel.Html} is enclosed in a red-dotted line, because it is incorrectly provided to <starcounter-include> without an app namespace. Your options are to either: 
+                console.warn(`The view ${viewModel.Html} is enclosed in a red-dotted line, because it is incorrectly provided to <starcounter-include> without an app namespace. Your options are to either:
 - Make it blendable by using Self.GET on server-side, or
 - Use <imported-template> instead of <starcounter-include> and remove declarative-shadow-dom from the nested view
 

--- a/test/deprecated-partial-attrib/warning.html
+++ b/test/deprecated-partial-attrib/warning.html
@@ -63,29 +63,30 @@
                 "doesItWork": "worked!"
             }
         };
-        describe('When partial attribute is set in HTML, a warning should be thrown', function () {
+        describe('When partial attribute is set in HTML', function () {
             before(function (done) {
                 sinon.spy(console, 'warn');
-                fixture('given-in-HTML');
+                scInclude = fixture('given-in-HTML').querySelector('starcounter-include');
                 // wait for polyfills
                 setTimeout(done, 50);
             });
-            it('should throw a warning about using `partial` attribute', function () {
+            it('should throw a warning about using `partial` attribute, on this element', function () {
                 expect(console.warn).to.be.called;
+                expect(console.warn).to.be.calledWith(sinon.match(/partial.*deprecated/),scInclude);
             });
             after(function () {
                 console.warn.restore();
             })
         });
 
-        describe('When partial property is set via JS, a warning should be thrown', function () {
+        describe('When partial property is set via JS', function () {
             before(function (done) {
                 sinon.spy(console, 'warn');
                 scInclude = fixture('given-in-JS').querySelector('starcounter-include');
                 // wait for polyfills
                 setTimeout(done, 50);
             });
-            it('should throw a warning about using `partial` property', function () {
+            it('should throw a warning about using `partial` property, on this element', function () {
                 // control test
                 expect(console.warn).to.be.not.called;
 
@@ -93,20 +94,24 @@
 
                 // test now
                 expect(console.warn).to.be.called;
+                expect(console.warn).to.be.calledWith(sinon.match(/partial.*deprecated/),scInclude);
             });
             after(function () {
                 console.warn.restore();
             })
         });
 
-        describe('When partial property is set via dom-bind, a warning should be thrown', function () {
+        describe('When partial property is set via dom-bind', function () {
             before(function (done) {
                 sinon.spy(console, 'warn');
                 domBind = fixture('dom-bind').querySelector('dom-bind');
                 // wait for polyfills
-                setTimeout(done, 50);
+                setTimeout(()=>{
+                    scInclude = domBind.parentNode.querySelector('starcounter-include');
+                    done();
+                }, 50);
             });
-            it('should throw a warning about using `partial` property', function () {
+            it('should throw a warning about using `partial` property, on this element', function () {
                 // control test
                 expect(console.warn).to.be.not.called;
 
@@ -114,6 +119,7 @@
 
                 // test now
                 expect(console.warn).to.be.called;
+                expect(console.warn).to.be.calledWith(sinon.match(/partial.*deprecated/),scInclude);
             });
             after(function () {
                 console.warn.restore();


### PR DESCRIPTION
in the deprecated warning,
to make finding starcounter-include in question easier.