### PR TITLE
Separate composition management slightly outside of the element

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ Property   | Options           | Default | Description
 Name                                    | Detail                 | Description
 ---                                     | ---                    | ---
 `starcounter-include-composition-saved` | *String* stored composition | Triggered once composition is saved
-`partial-changed`                       | *Object* `{value: storedComposition, path: 'partial.{compositionProvider}.Composition$'}` | Polymer notification protocol compliant event to notify about `partial.{compositionProvider}.Composition$` change, triggered once composition is saved.
-`view-model-changed`                       | *Object* `{value: storedComposition, path: 'viewModel.{compositionProvider}.Composition$'}` | Polymer notification protocol compliant event to notify about `partial.{compositionProvider}.Composition$` change, triggered once composition is saved.
+`partial-changed`                       | *Object* `{value: storedComposition, path: 'partial.{compositionProvider}.Composition'}` | Polymer notification protocol compliant event to notify about `partial.{compositionProvider}.Composition` change, triggered once composition is saved.
+`view-model-changed`                       | *Object* `{value: storedComposition, path: 'viewModel.{compositionProvider}.Composition'}` | Polymer notification protocol compliant event to notify about `partial.{compositionProvider}.Composition` change, triggered once composition is saved.
 `presentation-loaded`                   | none                   | When all links from a stamped presentation finished loading (with success or failure).
 
 ## Render-blocking links

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -291,7 +291,7 @@ version: 5.3.0
                     this.partialId = compositionProvider.PartialId;
                     this.temporaryComposition = null;
 					// For backward compatibility
-					var compositionProviderComposition = compositionProvider.Composition || compositionProvider.Composition$;
+					var compositionProviderComposition = compositionProvider.Composition;
                     if (compositionString === "") {
                         //this is a request from starcounter-layout-html-editor to reset to default composition
                     }

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -296,8 +296,8 @@ version: 5.3.0
                         //this is a request from starcounter-layout-html-editor to reset to default composition
                     }
                     else if (compositionProviderComposition) {
+                        this.storedLayout = compositionProviderComposition; //should always be string
                         return this._renderCompositionChange(compositionProviderComposition, () => {
-                            this.storedLayout = compositionProviderComposition; //should always be string
                             const merged = this.stringToDocumentFragment(this.storedLayout);
 
                             if (compositionProvider.ViewUris) {

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -402,6 +402,14 @@ version: 5.3.0
                 ){
                     this._updateHref();
                     return;
+                } else if (
+                    // Just the composition was changed
+                    // and it's different than already stored one
+                    subPath === this.compositionProvider + '.Composition' &&
+                    value != this.storedLayout
+                ) {
+                    this.updateComposition();
+                    return;
                 }
                 // Notify about model change
                 if (this.template._setPendingPropertyOrPath) {

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -456,22 +456,6 @@ version: 5.3.0
                 return undefined;
             }
         };
-        /**
-         * Saves given or current composition as stored one, notifies binding about it.
-         * @param  {String} [compositionStr] composition to be saved, if not given current one will be used
-         * @deprecated
-         */
-        StarcounterIncludePrototype.saveLayout = function(compositionStr){
-			console.warn("This method of saving composition is deprecated and will be removed soon. Please use the current version of Blending app.");
-            compositionStr = compositionStr || this.shadowRoot.innerHTML;
-            this.viewModel[this.compositionProvider].Composition$ = compositionStr;
-            this.dispatchEvent(new CustomEvent("starcounter-include-composition-saved", {detail: compositionStr}));
-            // trigger polymer-notification-protocol-compilant event
-            var notificationPath = this.compositionProvider + '.Composition$';
-            this.dispatchEvent(new CustomEvent("partial-changed", {detail: {value: compositionStr, path: 'partial.' + notificationPath}}));
-            this.dispatchEvent(new CustomEvent("view-model-changed", {detail: {value: compositionStr, path: 'viewModel.' + notificationPath}}));
-        };
-
         // stringToDocumentFragment(strHTML) from http://stackoverflow.com/a/25214113/868184
         /**
          * Creates DocumentFragment from a string.

--- a/test/composition/custom.html
+++ b/test/composition/custom.html
@@ -87,18 +87,6 @@
                 it('should NOT overwrite Composition$', function () {
                     expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.equal(composition$);
                 });
-                describe('after saveLayout() is called', function () {
-                    beforeEach(function () {
-                        scInclude.saveLayout();
-                        scInclude.updateComposition(); //simulate notifyPath which can trigger updateComposition
-                    });
-                    it('should overwrite Composition$', function () {
-                        expect(scInclude.viewModel.CompositionProvider_0.Composition$.trim()).to.be.equal(temporaryComposition);
-                    });
-                    it('should render the temporary composition', function () {
-                        expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(temporaryComposition);
-                    });
-                });
             });
             describe('after view-model property is replaced with itself', function () {
                 it('should keep using the existing composition', function (done) { //otherwise ViewKeeper (aka workspaces) do not keep state in Firefox and Edge

--- a/test/composition/custom.html
+++ b/test/composition/custom.html
@@ -23,7 +23,7 @@
             <starcounter-include view-model="{
                 &quot;CompositionProvider_0&quot;: {
                     &quot;PartialId&quot;: &quot;given PartialId&quot;,
-                    &quot;Composition$&quot;: &quot;customComposition!<slot></slot>&quot;
+                    &quot;Composition&quot;: &quot;customComposition!<slot></slot>&quot;
                 },
                 &quot;App&quot;: {
                     &quot;Html&quot;: &quot;template_w_declarative-shadow-dom.html&quot;,
@@ -70,10 +70,10 @@
                 });
             });
             describe('after composition is changed via `updateComposition` method', function () {
-                var composition$;
+                var composition;
                 var temporaryComposition = "temporary composition";
                 beforeEach(function () {
-                    composition$ = scInclude.viewModel.CompositionProvider_0.Composition$;
+                    composition = scInclude.viewModel.CompositionProvider_0.Composition;
                     scInclude.updateComposition(temporaryComposition);
                 });
                 it('should render the temporary composition', function () {
@@ -84,8 +84,8 @@
 
                     expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_DEFAULT);
                 });
-                it('should NOT overwrite Composition$', function () {
-                    expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.equal(composition$);
+                it('should NOT overwrite Composition', function () {
+                    expect(scInclude.viewModel.CompositionProvider_0.Composition).to.be.equal(composition);
                 });
             });
             describe('after view-model property is replaced with itself', function () {

--- a/test/composition/custom.html
+++ b/test/composition/custom.html
@@ -59,12 +59,12 @@
                     expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_DEFAULT);
                 });
             });
-            describe('after viewModel property is replaced with a view-model that contains a fallback composition', function () {
+            describe('after viewModel property is replaced with a view-model that contains an empty composition', function () {
                 beforeEach(function (done) {
                     scInclude.viewModel = partialWithFallback();
                     setTimeout(done, 500);
                 });
-                it('should use it as its composition', function () {
+                it('should use fallback as its composition', function () {
                     expect(scInclude.shadowRoot).to.be.not.null;
                     expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_FALLBACK);
                 });
@@ -79,12 +79,12 @@
                 it('should render the temporary composition', function () {
                     expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(temporaryComposition);
                 });
-                it('should return to default after resetting', function () {
+                it('should return to default after resetting (setting to empty)', function () {
                     scInclude.updateComposition(""); //this is how starcounter-layout-html-editor resets
 
                     expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_DEFAULT);
                 });
-                it('should NOT overwrite Composition', function () {
+                it('should NOT overwrite `compositionProvider.Composition`', function () {
                     expect(scInclude.viewModel.CompositionProvider_0.Composition).to.be.equal(composition);
                 });
             });

--- a/test/composition/default-declarative-shadow-dom.html
+++ b/test/composition/default-declarative-shadow-dom.html
@@ -139,18 +139,6 @@
             it('should NOT overwrite Composition$', function() {
                 expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.equal(composition$);
             });
-            describe('after saveLayout() is called', function() {
-                beforeEach(function() {
-                    scInclude.saveLayout();
-                    scInclude.updateComposition(); //simulate notifyPath which can trigger updateComposition
-                });
-                it('should overwrite Composition$', function() {
-                    expect(scInclude.viewModel.CompositionProvider_0.Composition$.trim()).to.be.equal(temporaryComposition);
-                });
-                it('should render the temporary composition', function() {
-                    expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(temporaryComposition);
-                });
-            });
         });
         describe('after partial property is replaced with the partial that does custom subset composition', function () {
             beforeEach(function (done) {
@@ -179,18 +167,6 @@
                 });
                 it('should NOT overwrite Composition$', function() {
                     expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.equal(composition$);
-                });
-                describe('after saveLayout() is called', function() {
-                    beforeEach(function() {
-                        scInclude.saveLayout();
-                        scInclude.updateComposition(); //simulate notifyPath which can trigger updateComposition
-                    });
-                    it('should overwrite Composition$', function() {
-                        expect(scInclude.viewModel.CompositionProvider_0.Composition$.trim()).to.be.equal(temporaryComposition);
-                    });
-                    it('should render the temporary composition', function() {
-                        expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(temporaryComposition);
-                    });
                 });
             });
         });

--- a/test/composition/default-declarative-shadow-dom.html
+++ b/test/composition/default-declarative-shadow-dom.html
@@ -24,7 +24,7 @@
             <starcounter-include partial="{
                 &quot;CompositionProvider_0&quot;: {
                     &quot;PartialId&quot;: &quot;given PartialId&quot;,
-                    &quot;Composition$&quot;: &quot;&quot;
+                    &quot;Composition&quot;: &quot;&quot;
                 },
                 &quot;App&quot;: {
                     &quot;Html&quot;: &quot;template_w_declarative-shadow-dom.html&quot;,
@@ -38,7 +38,7 @@
             <starcounter-include partial="{
                 &quot;CompositionProvider_0&quot;: {
                     &quot;PartialId&quot;: &quot;given PartialId&quot;,
-                    &quot;Composition$&quot;: &quot;&quot;
+                    &quot;Composition&quot;: &quot;&quot;
                 },
                 &quot;App&quot;: {
                     &quot;Html&quot;: &quot;template_w_other_presentation.html&quot;,
@@ -64,7 +64,7 @@
         var alternativePartial = {
             "CompositionProvider_0": {
                 "PartialId": "given PartialId",
-                "Composition$": "",
+                "Composition": "",
                 "ViewUris": []
             },
             "App": {
@@ -75,7 +75,7 @@
         var alternativePartialWithTwo = {
             "CompositionProvider_0": {
                 "PartialId": "given PartialId",
-                "Composition$": "custom!",
+                "Composition": "custom!",
                 "ViewUris": ["template_w_declarative-shadow-dom.html"]
             },
             "App1": {
@@ -122,10 +122,10 @@
             });
         });
         describe('after composition is changed from custom subset via `updateComposition` method', function() {
-            var composition$;
+            var composition;
             var temporaryComposition = "temporary composition";
             beforeEach(function() {
-                composition$ = scInclude.viewModel.CompositionProvider_0.Composition$;
+                composition = scInclude.viewModel.CompositionProvider_0.Composition;
                 scInclude.updateComposition(temporaryComposition);
             });
             it('should render the temporary composition', function() {
@@ -136,8 +136,8 @@
                 expect(scInclude.shadowRoot.innerHTML).to.be
                     .sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_COMPOSITION);
             });
-            it('should NOT overwrite Composition$', function() {
-                expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.equal(composition$);
+            it('should NOT overwrite Composition', function() {
+                expect(scInclude.viewModel.CompositionProvider_0.Composition).to.be.equal(composition);
             });
         });
         describe('after partial property is replaced with the partial that does custom subset composition', function () {
@@ -151,10 +151,10 @@
                     .sameHTMLString_ignoringShadyCSSPolyfillClasses("custom!" + REFERENCE_ALTERNATIVE_COMPOSITION);
             });
             describe('after composition is changed from custom subset via `updateComposition` method', function() {
-                var composition$;
+                var composition;
                 var temporaryComposition = "temporary composition";
                 beforeEach(function() {
-                    composition$ = scInclude.viewModel.CompositionProvider_0.Composition$;
+                    composition = scInclude.viewModel.CompositionProvider_0.Composition;
                     scInclude.updateComposition(temporaryComposition);
                 });
                 it('should render the temporary composition', function() {
@@ -165,8 +165,8 @@
                     expect(scInclude.shadowRoot.innerHTML).to.be
                         .sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_COMPOSITION + REFERENCE_ALTERNATIVE_COMPOSITION);
                 });
-                it('should NOT overwrite Composition$', function() {
-                    expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.equal(composition$);
+                it('should NOT overwrite Composition', function() {
+                    expect(scInclude.viewModel.CompositionProvider_0.Composition).to.be.equal(composition);
                 });
             });
         });

--- a/test/composition/fallback.html
+++ b/test/composition/fallback.html
@@ -84,18 +84,6 @@
             it('should NOT overwrite Composition$', function() {
                 expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.equal("");
             });
-            describe('after saveLayout() is called', function() {
-                beforeEach(function() {
-                    scInclude.saveLayout();
-                    scInclude.updateComposition(); //simulate notifyPath which can trigger updateComposition
-                });
-                it('should overwrite Composition$', function() {
-                    expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(temporaryComposition);
-                });
-                it('should render the temporary composition', function() {
-                    expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(temporaryComposition);
-                });
-            });
         });
         describe('after partial property is replaced with itself', function() {
             it('should keep using the existing composition', function(done) { //otherwise ViewKeeper (aka workspaces) do not keep state in Firefox and Edge

--- a/test/composition/fallback.html
+++ b/test/composition/fallback.html
@@ -23,7 +23,7 @@
             <starcounter-include partial="{
                 &quot;CompositionProvider_0&quot;: {
                     &quot;PartialId&quot;: &quot;given PartialId&quot;,
-                    &quot;Composition$&quot;: &quot;&quot;
+                    &quot;Composition&quot;: &quot;&quot;
                 },
                 &quot;App&quot;: {
                     &quot;Html&quot;: &quot;templateToInclude.html&quot;,
@@ -81,8 +81,8 @@
                 scInclude.updateComposition(""); //this is how starcounter-layout-html-editor resets
                 expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_FALLBACK);
             });
-            it('should NOT overwrite Composition$', function() {
-                expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.equal("");
+            it('should NOT overwrite Composition', function() {
+                expect(scInclude.viewModel.CompositionProvider_0.Composition).to.be.equal("");
             });
         });
         describe('after partial property is replaced with itself', function() {

--- a/test/composition/parent-declarative-shadow-dom.html
+++ b/test/composition/parent-declarative-shadow-dom.html
@@ -143,18 +143,6 @@
             it('should NOT overwrite Composition$', function() {
                 expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.equal(composition$);
             });
-            describe('after saveLayout() is called', function() {
-                beforeEach(function() {
-                    scInclude.saveLayout();
-                    scInclude.updateComposition(); //simulate notifyPath which can trigger updateComposition
-                });
-                it('should overwrite Composition$', function() {
-                    expect(scInclude.viewModel.CompositionProvider_0.Composition$.trim()).to.be.equal(temporaryComposition);
-                });
-                it('should render the temporary composition', function() {
-                    expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(temporaryComposition);
-                });
-            });
         });
         describe('after partial property is replaced with the partial that does custom subset composition', function () {
             beforeEach(function (done) {
@@ -184,18 +172,6 @@
                 });
                 it('should NOT overwrite Composition$', function() {
                     expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.equal(composition$);
-                });
-                describe('after saveLayout() is called', function() {
-                    beforeEach(function() {
-                        scInclude.saveLayout();
-                        scInclude.updateComposition(); //simulate notifyPath which can trigger updateComposition
-                    });
-                    it('should overwrite Composition$', function() {
-                        expect(scInclude.viewModel.CompositionProvider_0.Composition$.trim()).to.be.equal(temporaryComposition);
-                    });
-                    it('should render the temporary composition', function() {
-                        expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(temporaryComposition);
-                    });
                 });
             });
         });

--- a/test/composition/parent-declarative-shadow-dom.html
+++ b/test/composition/parent-declarative-shadow-dom.html
@@ -24,7 +24,7 @@
             <starcounter-include partial="{
                 &quot;CompositionProvider_0&quot;: {
                     &quot;PartialId&quot;: &quot;given PartialId&quot;,
-                    &quot;Composition$&quot;: &quot;&quot;
+                    &quot;Composition&quot;: &quot;&quot;
                 },
                 &quot;App&quot;: {
                     &quot;Html&quot;: &quot;template_w_declarative-shadow-dom.html&quot;,
@@ -42,7 +42,7 @@
             <starcounter-include partial="{
                 &quot;CompositionProvider_0&quot;: {
                     &quot;PartialId&quot;: &quot;given PartialId&quot;,
-                    &quot;Composition$&quot;: &quot;&quot;
+                    &quot;Composition&quot;: &quot;&quot;
                 },
                 &quot;App&quot;: {
                     &quot;Html&quot;: &quot;template_w_declarative-shadow-dom.html&quot;,
@@ -72,7 +72,7 @@
         var alternativePartial = {
             "CompositionProvider_0": {
                 "PartialId": "given PartialId",
-                "Composition$": "",
+                "Composition": "",
                 "ViewUris": []
             },
             "App": {
@@ -83,7 +83,7 @@
         var alternativePartialWithTwo = {
             "CompositionProvider_0": {
                 "PartialId": "given PartialId",
-                "Composition$": "custom!",
+                "Composition": "custom!",
                 "ViewUris": ["template_w_declarative-shadow-dom.html"]
             },
             "App1": {
@@ -126,10 +126,10 @@
             });
         });
         describe('after composition is changed from custom subset via `updateComposition` method', function() {
-            var composition$;
+            var composition;
             var temporaryComposition = "temporary composition";
             beforeEach(function() {
-                composition$ = scInclude.viewModel.CompositionProvider_0.Composition$;
+                composition = scInclude.viewModel.CompositionProvider_0.Composition;
                 scInclude.updateComposition(temporaryComposition);
             });
             it('should render the temporary composition', function() {
@@ -140,8 +140,8 @@
                 expect(scInclude.shadowRoot.innerHTML).to.be
                     .sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_COMPOSITION);
             });
-            it('should NOT overwrite Composition$', function() {
-                expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.equal(composition$);
+            it('should NOT overwrite Composition', function() {
+                expect(scInclude.viewModel.CompositionProvider_0.Composition).to.be.equal(composition);
             });
         });
         describe('after partial property is replaced with the partial that does custom subset composition', function () {
@@ -155,10 +155,10 @@
                     .sameHTMLString_ignoringShadyCSSPolyfillClasses("custom!" + REFERENCE_ALTERNATIVE_COMPOSITION);
             });
             describe('after composition is changed from custom subset via `updateComposition` method', function() {
-                var composition$;
+                var composition;
                 var temporaryComposition = "temporary composition";
                 beforeEach(function() {
-                    composition$ = scInclude.viewModel.CompositionProvider_0.Composition$;
+                    composition = scInclude.viewModel.CompositionProvider_0.Composition;
                     scInclude.updateComposition(temporaryComposition);
                 });
                 it('should render the temporary composition', function() {
@@ -170,8 +170,8 @@
                     expect(scInclude.shadowRoot.innerHTML).to.be
                         .sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_COMPOSITION);
                 });
-                it('should NOT overwrite Composition$', function() {
-                    expect(scInclude.viewModel.CompositionProvider_0.Composition$).to.be.equal(composition$);
+                it('should NOT overwrite Composition', function() {
+                    expect(scInclude.viewModel.CompositionProvider_0.Composition).to.be.equal(composition);
                 });
             });
         });

--- a/test/helpers/composition-fixtures.js
+++ b/test/helpers/composition-fixtures.js
@@ -14,7 +14,7 @@ function partialWithCustom() {
     return {
         "CompositionProvider_0": {
             "PartialId": "given PartialId",
-            "Composition$": "customComposition!<slot></slot>"
+            "Composition": "customComposition!<slot></slot>"
         },
         "App": {
             "Html": "template_w_declarative-shadow-dom.html",
@@ -27,7 +27,7 @@ function partialWithDefault() {
     return {
         "CompositionProvider_0": {
             "PartialId": "given PartialId",
-            "Composition$": ""
+            "Composition": ""
         },
         "App": {
             "Html": "template_w_declarative-shadow-dom.html",
@@ -40,7 +40,7 @@ function partialWithFallback() {
     return {
         "CompositionProvider_0": {
             "PartialId": "given PartialId",
-            "Composition$": ""
+            "Composition": ""
         },
         "App": {
             "Html": "templateToInclude.html",

--- a/test/shadowRoot/basic.html
+++ b/test/shadowRoot/basic.html
@@ -58,15 +58,15 @@
             });
         });
 
-        describe('when `.CompositionProvider_0.Composition$` property is set', function () {
+        describe('when `.CompositionProvider_0.Composition` property is set', function () {
             beforeEach(function (done) {
                 container = fixture('element');
                 domBind = container.querySelector('dom-bind');
                 // domBind.addEventListener('dom-change', function waitForDomBind(){
                     scInclude = container.querySelector('starcounter-include');
                     composition = document.querySelector('#composition').innerHTML;
-                    domBind.set('partial', {CompositionProvider_0:{Composition$: null}});
-                    domBind.set('partial.CompositionProvider_0.Composition$', composition);
+                    domBind.set('partial', {CompositionProvider_0:{Composition: null}});
+                    domBind.set('partial.CompositionProvider_0.Composition', composition);
                     // setTimeout(function waitForPolyfilledUpgrade(){
                         done();
                     // },100);

--- a/test/shadowRoot/smoke/webcomponents-webcomponentsjs-issues-648.html
+++ b/test/shadowRoot/smoke/webcomponents-webcomponentsjs-issues-648.html
@@ -33,7 +33,7 @@
                 compositionTemplate = document.querySelector('#composition');
     			scInclude.viewModel = {
     				CompositionProvider_0:{
-    					Composition$: compositionTemplate.innerHTML
+    					Composition: compositionTemplate.innerHTML
     				}
     			};
                 // scInclude.stamp();

--- a/test/view-model-attribute/cleanup_removed_partial_Layout.html
+++ b/test/view-model-attribute/cleanup_removed_partial_Layout.html
@@ -26,7 +26,7 @@
 
         const useShadowDOMV1 = Boolean(Element.prototype.attachShadow && Node.prototype.getRootNode);
         const DEFAULT_COMPOSITION = useShadowDOMV1 ? '<style>:host{display:block;}</style><slot></slot>' : '<style>:host{display:block;}</style><content select=":not([slot]),[slot=\'\']"></content>';
-        describe('cleanup changes of Composition$', function() {
+        describe('cleanup changes of Composition', function() {
             afterEach(function (done) {
                 // give more time to polyfill cleanup
                 setTimeout(done);
@@ -35,7 +35,7 @@
             var model = {
                 "Html": "../templateToInclude.html",
                 "CompositionProvider_0": {
-                    "Composition$": 'a Composition',
+                    "Composition": 'a Composition',
                     "PartialId": "given PartialId"
                 },
                 "doesItWork": "works!"
@@ -82,7 +82,7 @@
                     done();
                 });
 
-                it('when the `viewModel` property is changed to a view-model without Composition$', function(done) {
+                it('when the `viewModel` property is changed to a view-model without Composition', function(done) {
                     expect(instance).to.have.compositionAttached;
                     instance.viewModel = {
                         "Html": "../templateToInclude.html",
@@ -92,12 +92,12 @@
                     done();
                 });
 
-                it('when the `viewModel` property is changed to a view-model with empty Composition$', function(done) {
+                it('when the `viewModel` property is changed to a view-model with empty Composition', function(done) {
                     expect(instance).to.have.compositionAttached;
                     instance.viewModel = {
                         "Html": "../templateToInclude.html",
                         "CompositionProvider_0": {
-                            "Composition$": "",
+                            "Composition": "",
                             "PartialId": ""
                         },
                         "doesItWork": "works!"

--- a/test/view-model-attribute/cleanup_removed_partial_Layout.html
+++ b/test/view-model-attribute/cleanup_removed_partial_Layout.html
@@ -25,7 +25,7 @@
         const isWebkit = navigator.vendor && navigator.vendor.indexOf("Apple") > -1;
 
         const useShadowDOMV1 = Boolean(Element.prototype.attachShadow && Node.prototype.getRootNode);
-        const DEFAULT_COMPOSITION = useShadowDOMV1 ? '<style>:host{display:block;}</style><slot></slot>' : '<style>:host{display:block;}</style><content select=":not([slot]),[slot=\'\']"></content>';
+        const FALLBACK_COMPOSITION = useShadowDOMV1 ? '<style>:host{display:block;}</style><slot></slot>' : '<style>:host{display:block;}</style><content select=":not([slot]),[slot=\'\']"></content>';
         describe('cleanup changes of Composition', function() {
             afterEach(function (done) {
                 // give more time to polyfill cleanup
@@ -33,8 +33,8 @@
             });
             var instance;
             var model = {
-                "Html": "../templateToInclude.html",
                 "CompositionProvider_0": {
+                    "Html": "../templateToInclude.html",
                     "Composition": 'a Composition',
                     "PartialId": "given PartialId"
                 },
@@ -42,9 +42,11 @@
             };
 
             describe("should remove Composition when", function() {
-                beforeEach(function() {
+                beforeEach(function(done) {
                     instance = fixture('nothing');
                     instance.viewModel = clone(model);
+                    // wait for template to be stamped, and for the model to get attached
+                    setTimeout(done, 100);
                 });
 
                 it('the `view-model` attribute is changed to an empty string', function(done) {
@@ -105,6 +107,27 @@
                     expect(instance).to.have.compositionCleanedUp;
                     done();
                 });
+
+                it('when the `viewModel.CompositionProvider_0.Composition` property is changed to empty string via Polymer notification', function(done) {
+                    expect(instance).to.have.compositionAttached;
+
+                    // mimic dom-bind, propagating set property
+                    instance.viewModel.CompositionProvider_0.Composition = '';
+                    instance._setPendingPropertyOrPath('viewModel.CompositionProvider_0.Composition', '');
+
+                    expect(instance).to.have.compositionCleanedUp;
+                    done();
+                });
+                it('when the `viewModel.CompositionProvider_0.Composition` property is changed to `null` via Polymer notification', function(done) {
+                    expect(instance).to.have.compositionAttached;
+
+                    // mimic dom-bind, propagating set property
+                    instance.viewModel.CompositionProvider_0.Composition = null;
+                    instance._setPendingPropertyOrPath('viewModel.CompositionProvider_0.Composition', null);
+
+                    expect(instance).to.have.compositionCleanedUp;
+                    done();
+                });
             });
 
             function clone(obj) {
@@ -119,7 +142,7 @@
         chai.Assertion.addProperty('compositionCleanedUp', function () {
           var obj = chai.util.flag(this, 'object');
           new chai.Assertion(obj).to.be.instanceof(HTMLElement);
-          new chai.Assertion(obj.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(DEFAULT_COMPOSITION);
+          new chai.Assertion(obj.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(FALLBACK_COMPOSITION);
         });
     </script>
 

--- a/test/view-model-attribute/nested-html/stamped_from_polymer_template.html
+++ b/test/view-model-attribute/nested-html/stamped_from_polymer_template.html
@@ -17,6 +17,7 @@
     <link rel="import" href="../../../starcounter-include.html">
     <script src="../../helpers/WCT-Polyfill_bugs_workaround.js"></script>
     <script src="../../helpers/composition-fixtures.js"></script>
+    <script src="../../helpers/compareHTMLStrings.js"></script>
 </head>
 
 <body>
@@ -317,7 +318,7 @@
                     });
 
                     it('should change the shadowRoot to the fallback composition', function () {
-                        expect(include.shadowRoot.innerHTML).to.equal(REFERENCE_FALLBACK);
+                        expect(include.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_FALLBACK);
                     });
                 });
 
@@ -330,7 +331,7 @@
                     });
 
                     it('should change the shadowRoot to the fallback composition', function () {
-                        expect(include.shadowRoot.innerHTML).to.equal(REFERENCE_FALLBACK);
+                        expect(include.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_FALLBACK);
                     });
                 });
             });

--- a/test/view-model-attribute/nested-html/stamped_from_polymer_template.html
+++ b/test/view-model-attribute/nested-html/stamped_from_polymer_template.html
@@ -1,4 +1,3 @@
-
 <!doctype html>
 <html>
 
@@ -17,6 +16,7 @@
     <!-- Step 1: import the element to test -->
     <link rel="import" href="../../../starcounter-include.html">
     <script src="../../helpers/WCT-Polyfill_bugs_workaround.js"></script>
+    <script src="../../helpers/composition-fixtures.js"></script>
 </head>
 
 <body>
@@ -39,12 +39,13 @@
                     'Html': 'scope2Html;,/?:@&=+$',
                     'doesItWork': 'works!'
                 },
-                'scope3': {
+                'CompositionProvider_0': {
+                    'Composition': 'custom composition',
                     'doesItWork': 'works!'
                 }
             };
         };
-        const MERGED_URL = '/sc/htmlmerger?scope1=scope1Html&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=';
+        const MERGED_URL = '/sc/htmlmerger?scope1=scope1Html&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&CompositionProvider_0=';
         var changedPartial = {
             'scopeA': {
                 'Html': 'scopeAHtml',
@@ -153,7 +154,7 @@
                                 'Html': 'scope2Html;,/?:@&=+$',
                                 'doesItWork': 'still works!'
                             },
-                            'scope3': {
+                            'CompositionProvider_0': {
                                 'doesItWork': 'still works!'
                             }
                         };
@@ -178,8 +179,8 @@
                     });
 
                     it('should attach new `.Html` property as href attribute and property for `<imported-template>`', function () {
-                        expect(importedTemplate.getAttribute("href")).to.equal('/sc/htmlmerger?scope1=scopeAHtml&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
-                        expect(importedTemplate.href).to.equal('/sc/htmlmerger?scope1=scopeAHtml&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
+                        expect(importedTemplate.getAttribute("href")).to.equal('/sc/htmlmerger?scope1=scopeAHtml&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&CompositionProvider_0=');
+                        expect(importedTemplate.href).to.equal('/sc/htmlmerger?scope1=scopeAHtml&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&CompositionProvider_0=');
                     });
                     it('should NOT attach new view-model model to `imported-template` immediately', function () {
                         expect(importedTemplate.model).to.equal(viewModel);
@@ -263,8 +264,8 @@
                     });
 
                     it('should attach new `.Html` property as href attribute and property for `<imported-template>`', function () {
-                        expect(importedTemplate.getAttribute("href")).to.equal('/sc/htmlmerger?scope1=changedHtml&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
-                        expect(importedTemplate.href).to.equal('/sc/htmlmerger?scope1=changedHtml&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&scope3=');
+                        expect(importedTemplate.getAttribute("href")).to.equal('/sc/htmlmerger?scope1=changedHtml&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&CompositionProvider_0=');
+                        expect(importedTemplate.href).to.equal('/sc/htmlmerger?scope1=changedHtml&scope2=scope2Html%3B%2C%2F%3F%3A%40%26%3D%2B%24&CompositionProvider_0=');
                     });
                     it('should NOT forward the notification to `imported-template` immediately', function () {
                         expect(importedTemplate._setPendingPropertyOrPath).not.to.be.called;
@@ -291,6 +292,45 @@
                     });
                     it('should attach same partial model to `imported-template`', function () {
                         expect(importedTemplate.model).to.equal(viewModel);
+                    });
+                });
+
+                describe('after `dom-bind`` changed composition provider\'s `Composition` property (e.g. `viewModel.CompositionProvider_0.Composition`) to a new one', function () {
+                    var changedComposition;
+                    beforeEach(function() {
+                        sinon.stub(importedTemplate, "_setPendingPropertyOrPath");
+                        changedComposition = 'changed custom composition';
+                        domBind.set('model.Page.CompositionProvider_0.Composition', changedComposition);
+                    });
+
+                    it('should change the shadowRoot to the given composition', function () {
+                        expect(include.shadowRoot.innerHTML).to.equal(changedComposition);
+                    });
+                });
+
+                describe('after `dom-bind`` changed composition provider\'s `Composition` property (e.g. `viewModel.CompositionProvider_0.Composition`) to an empty one', function () {
+                    var changedComposition;
+                    beforeEach(function() {
+                        sinon.stub(importedTemplate, "_setPendingPropertyOrPath");
+                        changedComposition = '';
+                        domBind.set('model.Page.CompositionProvider_0.Composition', changedComposition);
+                    });
+
+                    it('should change the shadowRoot to the fallback composition', function () {
+                        expect(include.shadowRoot.innerHTML).to.equal(REFERENCE_FALLBACK);
+                    });
+                });
+
+                describe('after `dom-bind`` changed composition provider\'s `Composition` property (e.g. `viewModel.CompositionProvider_0.Composition`) to `null`', function () {
+                    var changedComposition;
+                    beforeEach(function() {
+                        sinon.stub(importedTemplate, "_setPendingPropertyOrPath");
+                        changedComposition = '';
+                        domBind.set('model.Page.CompositionProvider_0.Composition', changedComposition);
+                    });
+
+                    it('should change the shadowRoot to the fallback composition', function () {
+                        expect(include.shadowRoot.innerHTML).to.equal(REFERENCE_FALLBACK);
                     });
                 });
             });


### PR DESCRIPTION
 - Remove save layout function, as now Blending Editor, should be responsible for that.
Starcounter/Blending#471
 - Use compositionProvider.Composition` instead of `..Composition$` - not to maintain to many backward compatibility layers
 - Make element observe Polymer notifications for `compositionProvider.Composition` - to be able to react on server-side changes triggered by any means, not just composition editor custom element.
 - Save updated compositionProvider's custom composition as stored one, even if it's the same as current temporary one, as after closing the editor changes were reverted not to the saved state, but to the state before editing was started Starcounter/Blending#460

All above are part of Starcounter/Blending#471

------

- I'm not sure whether we should support non-Polymer scenario for updating just `viewModel.CompositionProvider.Composition`. As for now we don't which is a hole in vanillaJS story, which AFAIK is still not used anywhere yet
- I'm not adding any tests for `.storedLayout`, as I would like to change it in future, so the `sc-include` will not have any cache. It should be editor's responsibility to manage that. I'd like to release it with `.storedLayout` support to make smaller steps with Blending changes.

