### PR TITLE
Reflect composition type, cleanup resetting

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Attribute     | Options  | Default      | Description
 `partial`     | *JSON*   |              | Set to provide partial JSON view-model. It's also a `partial` property.
 `partial-id`  | *String* |              | **Read-only** attribute that represents `PartialID` fetched from `partial` JSON. It's also a `partialId` property.
 `view-model`  | *JSON*   |              | Alias for `partial`
+`composition` | *String* |              | **Read-only** attribute that reflects currently used [composition kind](#kinds-of-compositions)
 
 ## Properties
 

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -277,82 +277,87 @@ version: 5.4.0
          * If parent composition not given, fetches default composition from the imported template.
          * If default composition not given, uses fallback composition.
          * Warning: the temporary composition might come from https://github.com/Starcounter/starcounter-layout-html-editor/blob/17b21f729facd9a8dcd4241fb5c48cb71de11af5/starcounter-layout-html-editor.html#L253
+         * compositionString given as `""` is considered `null`
+         * TODO: support empty composition
          * @see .stampComposition
          * @param  {String} compositionString stringified HTML for new Shadow Root
          */
         StarcounterIncludePrototype.updateComposition = function(compositionString) {
+            // render temporary composition if given
             if (compositionString) {
                 this.setAttribute('composition', 'temporary');
-                this.temporaryComposition = compositionString;
                 return this._renderCompositionChange(compositionString, () => this.stringToDocumentFragment(compositionString));
             }
-            else {
-                const compositionProvider = this.viewModel && this.viewModel[this.compositionProvider];
-                if (compositionProvider) {
-                    this.partialId = compositionProvider.PartialId;
-                    this.temporaryComposition = null;
-					// For backward compatibility
-					var compositionProviderComposition = compositionProvider.Composition;
-                    if (compositionString === "") {
-                        //this is a request from starcounter-layout-html-editor to reset to default composition
-                    }
-                    else if (compositionProviderComposition) {
-                        this.storedLayout = compositionProviderComposition; //should always be string
-                        this.setAttribute('composition', 'custom');
-                        return this._renderCompositionChange(compositionProviderComposition, () => {
-                            const merged = this.stringToDocumentFragment(this.storedLayout);
+            // this is a request from composition editor to reset to default composition
+            const forceDefault = (compositionString === ""); // compositionString === null
 
-                            if (compositionProvider.ViewUris) {
-                                const keys = Object.keys(this.viewModel);
-                                for(let key of keys) {
-                                    const scoped = this.viewModel[key];
-                                    if (scoped && scoped.Html && compositionProvider.ViewUris.indexOf(scoped.Html) === -1) {
-                                        if (this.defaultComposition) {
-                                            this.template.scopedNodes.forEach((nodes) => {
-                                                if(nodes.scope === key) {
-                                                    nodes.forEach((node) => appendComposition(merged, node));
-                                                }
-                                            });
+            // look for custom compostion provider
+            const compositionProvider = this.viewModel && this.viewModel[this.compositionProvider];
+            let compositionProviderComposition = undefined;
+            if (compositionProvider) {
+                this.partialId = compositionProvider.PartialId;
+				compositionProviderComposition = compositionProvider.Composition;
+                // Store whatever is given in the view model - it's the stored composition/layout
+                this._storedLayout = compositionProviderComposition; //should always be string
+            } else {
+                this.partialId = null;
+            }
+
+            // If there is a custom composition render it
+            // Empty composition ("") is treat as none (`null`)
+            if (compositionProviderComposition && !forceDefault) {
+                this.setAttribute('composition', 'custom');
+                return this._renderCompositionChange(compositionProviderComposition, () => {
+                    // convert string from view-model, to actual document fragment
+                    const customComposition = this.stringToDocumentFragment(compositionProviderComposition);
+
+                    // append default compositions for views not covered by this composition
+                    if (compositionProvider.ViewUris) {
+                        const keys = Object.keys(this.viewModel);
+                        for(let key of keys) {
+                            const scoped = this.viewModel[key];
+                            if (scoped && scoped.Html && compositionProvider.ViewUris.indexOf(scoped.Html) === -1) {
+                                if (this.defaultComposition) {
+                                    this.template.scopedNodes.forEach((nodes) => {
+                                        if(nodes.scope === key) {
+                                            nodes.forEach((node) => appendComposition(customComposition, node));
                                         }
-                                        else {
-                                            return false;
-                                        }
-                                    }
+                                    });
+                                }
+                                else {
+                                    // BUG,TODO (tomalec): looks like a bug
+                                    // This means that if there *is* a custom composition, but it does not cover all views,
+                                    // and it happend that none of the views had a default composition,
+                                    // we would discard custom composition and use default -> fallback
+                                    return false;
                                 }
                             }
-
-                            return merged;
-                        });
+                        }
                     }
-                }
-                else {
-                    this.partialId = null;
-                }
 
-                // Find parent composition to clone (if have one)
-                const parentCompositionTemplate = Array.from(this.children)
-                    .find((element)=>{
-                        return element.matches
-                            && element.matches('template[is="declarative-shadow-dom"][presentation="parent"],template[is="declarative-shadow-dom"]:not([presentation])')
-                    });
-                const parentComposition = parentCompositionTemplate && parentCompositionTemplate.content;
-                if (parentComposition) {
-                    parentCompositionTemplate.setAttribute('presentation', 'parent');
-                    this.setAttribute('composition', 'parent');
-                    this.temporaryComposition = null;
-                    return this._renderCompositionChange(parentComposition, () => parentComposition.cloneNode(true));
-                }
-                if (this.defaultComposition) {
-                    this.temporaryComposition = null;
-                    this.setAttribute('composition', 'default');
-                    return this._renderCompositionChange(this.defaultComposition, () => this.defaultComposition.cloneNode(true));
-                }
-
-                if (!this.temporaryComposition) {
-                    this.setAttribute('composition', 'fallback');
-                    return this._renderCompositionChange("fallback", () => undefined);
-                }
+                    return customComposition;
+                });
             }
+            // Find parent composition to clone (if have one)
+            const parentCompositionTemplate = Array.from(this.children)
+                .find((element)=>{
+                    return element.matches
+                        && element.matches('template[is="declarative-shadow-dom"][presentation="parent"],template[is="declarative-shadow-dom"]:not([presentation])')
+                });
+            const parentComposition = parentCompositionTemplate && parentCompositionTemplate.content;
+            if (parentComposition) {
+                parentCompositionTemplate.setAttribute('presentation', 'parent');
+                this.setAttribute('composition', 'parent');
+                return this._renderCompositionChange(parentComposition, () => parentComposition.cloneNode(true));
+            }
+            if (this.defaultComposition) {
+                this.setAttribute('composition', 'default');
+                return this._renderCompositionChange(this.defaultComposition, () => this.defaultComposition.cloneNode(true));
+            }
+
+            // render fallback if there is nothing better
+            this.setAttribute('composition', 'fallback');
+            return this._renderCompositionChange("fallback", () => undefined);
         };
         // to fool Polymer into thinking `starcounter-include` is a polymer element thus forwarding notifications to it.
         StarcounterIncludePrototype.__dataHasAccessor = {partial: true, viewModel: true};
@@ -411,7 +416,7 @@ version: 5.4.0
                     // Just the composition was changed
                     // and it's different than already stored one
                     subPath === this.compositionProvider + '.Composition' &&
-                    value != this.storedLayout
+                    value != this._storedLayout
                 ) {
                     this.updateComposition();
                     return;

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -289,7 +289,7 @@ version: 5.4.0
                 return this._renderCompositionChange(compositionString, () => this.stringToDocumentFragment(compositionString));
             }
             // this is a request from composition editor to reset to default composition
-            const forceDefault = (compositionString === ""); // compositionString === null
+            const forceDefault = (compositionString === ""); // should be changed to compositionString === null
 
             // look for custom compostion provider
             const compositionProvider = this.viewModel && this.viewModel[this.compositionProvider];

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -298,7 +298,7 @@ version: 5.4.0
                 this.partialId = compositionProvider.PartialId;
 				compositionProviderComposition = compositionProvider.Composition;
                 // Store whatever is given in the view model - it's the stored composition/layout
-                this._storedLayout = compositionProviderComposition; //should always be string
+                this._storedComposition = compositionProviderComposition; //should always be string
             } else {
                 this.partialId = null;
             }
@@ -416,7 +416,7 @@ version: 5.4.0
                     // Just the composition was changed
                     // and it's different than already stored one
                     subPath === this.compositionProvider + '.Composition' &&
-                    value != this._storedLayout
+                    value != this._storedComposition
                 ) {
                     this.updateComposition();
                     return;

--- a/starcounter-include.html
+++ b/starcounter-include.html
@@ -282,6 +282,7 @@ version: 5.4.0
          */
         StarcounterIncludePrototype.updateComposition = function(compositionString) {
             if (compositionString) {
+                this.setAttribute('composition', 'temporary');
                 this.temporaryComposition = compositionString;
                 return this._renderCompositionChange(compositionString, () => this.stringToDocumentFragment(compositionString));
             }
@@ -297,6 +298,7 @@ version: 5.4.0
                     }
                     else if (compositionProviderComposition) {
                         this.storedLayout = compositionProviderComposition; //should always be string
+                        this.setAttribute('composition', 'custom');
                         return this._renderCompositionChange(compositionProviderComposition, () => {
                             const merged = this.stringToDocumentFragment(this.storedLayout);
 
@@ -336,16 +338,19 @@ version: 5.4.0
                 const parentComposition = parentCompositionTemplate && parentCompositionTemplate.content;
                 if (parentComposition) {
                     parentCompositionTemplate.setAttribute('presentation', 'parent');
+                    this.setAttribute('composition', 'parent');
                     this.temporaryComposition = null;
                     return this._renderCompositionChange(parentComposition, () => parentComposition.cloneNode(true));
                 }
                 if (this.defaultComposition) {
                     this.temporaryComposition = null;
+                    this.setAttribute('composition', 'default');
                     return this._renderCompositionChange(this.defaultComposition, () => this.defaultComposition.cloneNode(true));
                 }
 
                 if (!this.temporaryComposition) {
-                    return this._renderCompositionChange("temporary", () => undefined);
+                    this.setAttribute('composition', 'fallback');
+                    return this._renderCompositionChange("fallback", () => undefined);
                 }
             }
         };

--- a/test/composition/README.md
+++ b/test/composition/README.md
@@ -3,23 +3,33 @@ There are that many kinds of compositions:
 temporary
 custom
 custom subset with some default
+parent
 default
 fallback
 
 Therefore, there are that many composition transitions to test:
 
 temporary to custom
+temporary to parent
 temporary to default
 temporary to fallback
 
 custom to temporary
+custom to parent
 custom to default
 custom to fallback
 
 default to temporary
+default to parent
 default to custom
 default to fallback
 
 fallback to temporary
+fallback to parent
 fallback to custom
 fallback to default
+
+parent to temporary
+parent to custom
+parent to default
+parent to fallback

--- a/test/composition/custom.html
+++ b/test/composition/custom.html
@@ -91,10 +91,17 @@
                 it('should have composition attribute set to `temporary`', function () {
                     expect(scInclude).to.have.HTMLAttribute('composition').equal("temporary");
                 });
-                it('should return to default after resetting (setting to empty)', function () {
+                it('should return to default after force resetting (setting to empty)', function () {
                     scInclude.updateComposition(""); //this is how starcounter-layout-html-editor resets
 
                     expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_DEFAULT);
+                });
+
+                });
+                it('should return to custom after resetting/refreshing/discarding (calling `scInclude.updateComposition()`)', function () {
+                    scInclude.updateComposition(); //this is how starcounter-layout-html-editor resets
+
+                    expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_CUSTOM);
                 });
                 it('should NOT overwrite `compositionProvider.Composition`', function () {
                     expect(scInclude.viewModel.CompositionProvider_0.Composition).to.be.equal(composition);

--- a/test/composition/custom.html
+++ b/test/composition/custom.html
@@ -96,8 +96,6 @@
 
                     expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_DEFAULT);
                 });
-
-                });
                 it('should return to custom after resetting/refreshing/discarding (calling `scInclude.updateComposition()`)', function () {
                     scInclude.updateComposition(); //this is how starcounter-layout-html-editor resets
 

--- a/test/composition/custom.html
+++ b/test/composition/custom.html
@@ -49,7 +49,10 @@
 
                 expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_CUSTOM);
             });
-            describe('after viewModel property is replaced with a view-model that contains a default composition', function () {
+            it('should have composition attribute set to `custom`', function () {
+                expect(scInclude).to.have.HTMLAttribute('composition').equal("custom");
+            });
+            describe('after viewModel property is replaced with a view-model which views contain a default composition', function () {
                 beforeEach(function (done) {
                     scInclude.viewModel = partialWithDefault();
                     setTimeout(done, 500);
@@ -57,6 +60,9 @@
                 it('should use it as its composition', function () {
                     expect(scInclude.shadowRoot).to.be.not.null;
                     expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_DEFAULT);
+                });
+                it('should have composition attribute set to `default`', function () {
+                    expect(scInclude).to.have.HTMLAttribute('composition').equal("default");
                 });
             });
             describe('after viewModel property is replaced with a view-model that contains an empty composition', function () {
@@ -68,6 +74,9 @@
                     expect(scInclude.shadowRoot).to.be.not.null;
                     expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_FALLBACK);
                 });
+                it('should have composition attribute set to `fallback`', function () {
+                    expect(scInclude).to.have.HTMLAttribute('composition').equal("fallback");
+                });
             });
             describe('after composition is changed via `updateComposition` method', function () {
                 var composition;
@@ -78,6 +87,9 @@
                 });
                 it('should render the temporary composition', function () {
                     expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(temporaryComposition);
+                });
+                it('should have composition attribute set to `temporary`', function () {
+                    expect(scInclude).to.have.HTMLAttribute('composition').equal("temporary");
                 });
                 it('should return to default after resetting (setting to empty)', function () {
                     scInclude.updateComposition(""); //this is how starcounter-layout-html-editor resets

--- a/test/composition/default-declarative-shadow-dom.html
+++ b/test/composition/default-declarative-shadow-dom.html
@@ -102,6 +102,9 @@
             expect(scInclude.shadowRoot.innerHTML.trim()).to.be
                 .sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_COMPOSITION);
         });
+        it('should have composition attribute set to `default`', function () {
+            expect(scInclude).to.have.HTMLAttribute('composition').equal("default");
+        });
         it('should attach `default` as a value of the `presentation` attribute, to the templates', function () {
             Array.from(scInclude.children)
             .filter((element)=>element.matches && element.matches('template[is="declarative-shadow-dom"]'))
@@ -131,6 +134,9 @@
             it('should render the temporary composition', function() {
                 expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(temporaryComposition);
             });
+            it('should have composition attribute set to `temporary`', function () {
+                expect(scInclude).to.have.HTMLAttribute('composition').equal("temporary");
+            });
             it('should return to default after resetting', function() {
                 scInclude.updateComposition(""); //this is how starcounter-layout-html-editor resets
                 expect(scInclude.shadowRoot.innerHTML).to.be
@@ -159,6 +165,9 @@
                 });
                 it('should render the temporary composition', function() {
                     expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(temporaryComposition);
+                });
+                it('should have composition attribute set to `temporary`', function () {
+                    expect(scInclude).to.have.HTMLAttribute('composition').equal("temporary");
                 });
                 it('should return to default after resetting', function() {
                     scInclude.updateComposition(""); //this is how starcounter-layout-html-editor resets

--- a/test/composition/fallback.html
+++ b/test/composition/fallback.html
@@ -49,6 +49,9 @@
             expect(scInclude.shadowRoot).to.be.not.null;
             expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_FALLBACK);
         });
+        it('should have composition attribute set to `fallback`', function () {
+            expect(scInclude).to.have.HTMLAttribute('composition').equal("fallback");
+        });
         describe('after partial property is replaced with a partial that contains a default composition', function() {
             beforeEach(function(done) {
                 scInclude.partial = partialWithDefault();
@@ -57,6 +60,9 @@
             it('should use it as its composition', function() {
                 expect(scInclude.shadowRoot).to.be.not.null;
                 expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_DEFAULT);
+            });
+            it('should have composition attribute set to `default`', function () {
+                expect(scInclude).to.have.HTMLAttribute('composition').equal("default");
             });
         });
         describe('after partial property is replaced with a partial that contains a custom composition', function() {
@@ -68,6 +74,9 @@
                 expect(scInclude.shadowRoot).to.be.not.null;
                 expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_CUSTOM);
             });
+            it('should have composition attribute set to `custom`', function () {
+                expect(scInclude).to.have.HTMLAttribute('composition').equal("custom");
+            });
         });
         describe('after composition is changed via `updateComposition` method', function() {
             var temporaryComposition = "temporary composition";
@@ -76,6 +85,9 @@
             });
             it('should render the temporary composition', function() {
                 expect(scInclude.shadowRoot.innerHTML).to.be.sameHTMLString_ignoringShadyCSSPolyfillClasses(temporaryComposition);
+            });
+            it('should have composition attribute set to `temporary`', function () {
+                expect(scInclude).to.have.HTMLAttribute('composition').equal("temporary");
             });
             it('should return to fallback after resetting', function() {
                 scInclude.updateComposition(""); //this is how starcounter-layout-html-editor resets

--- a/test/composition/parent-declarative-shadow-dom.html
+++ b/test/composition/parent-declarative-shadow-dom.html
@@ -110,6 +110,9 @@
             expect(scInclude.shadowRoot.innerHTML.trim()).to.be
                 .sameHTMLString_ignoringShadyCSSPolyfillClasses(REFERENCE_COMPOSITION);
         });
+        it('should have composition attribute set to `parent`', function () {
+            expect(scInclude).to.have.HTMLAttribute('composition').equal("parent");
+        });
         it('should attach `parent` as a value of the `presentation` attribute, to the templates', function () {
             expect(scInclude.firstElementChild).to.have
                 .HTMLAttribute('presentation').equal('parent');
@@ -135,6 +138,9 @@
             it('should render the temporary composition', function() {
                 expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(temporaryComposition);
             });
+            it('should have composition attribute set to `temporary`', function () {
+                expect(scInclude).to.have.HTMLAttribute('composition').equal("temporary");
+            });
             it('should return to parent after resetting', function() {
                 scInclude.updateComposition(""); //this is how starcounter-layout-html-editor resets
                 expect(scInclude.shadowRoot.innerHTML).to.be
@@ -154,6 +160,9 @@
                 expect(scInclude.shadowRoot.innerHTML).to.be
                     .sameHTMLString_ignoringShadyCSSPolyfillClasses("custom!" + REFERENCE_ALTERNATIVE_COMPOSITION);
             });
+            it('should have composition attribute set to `custom`', function () {
+                expect(scInclude).to.have.HTMLAttribute('composition').equal("custom");
+            });
             describe('after composition is changed from custom subset via `updateComposition` method', function() {
                 var composition;
                 var temporaryComposition = "temporary composition";
@@ -163,6 +172,9 @@
                 });
                 it('should render the temporary composition', function() {
                     expect(scInclude.shadowRoot.innerHTML.trim()).to.be.equal(temporaryComposition);
+                });
+                it('should have composition attribute set to `temporary`', function () {
+                    expect(scInclude).to.have.HTMLAttribute('composition').equal("temporary");
                 });
                 it('should return to parent after resetting', function() {
 


### PR DESCRIPTION
- Reflect composition kind as an attribute, 
  to improve debugging, app development and composing
- Make resetting cleaner, 
  remove not needed `temporaryComposition` property,
  make `storedLayout` "private": `_storedLayout`